### PR TITLE
Implement FromStr for Url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,12 @@ impl<'a> UrlParser<'a> {
     }
 }
 
+impl std::from_str::FromStr for Url {
+    fn from_str(string: &str) -> Option<Url> {
+        Url::parse(string).ok()
+    }
+}
+
 
 /// Private convenience methods for use in parser.rs
 impl<'a> UrlParser<'a> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,6 +10,7 @@
 use std::char;
 use std::u32;
 use std::path;
+use std::from_str::FromStr;
 use super::{UrlParser, Url, RelativeSchemeData, NonRelativeSchemeData, Domain};
 
 
@@ -96,6 +97,15 @@ fn url_parsing() {
 
         assert!(!expected_failure, "Unexpected success for {}", input);
     }
+}
+
+#[test]
+fn url_parsing_from_str() {
+    let valid_url: Option<Url> = FromStr::from_str("http://www.example.com");
+    assert!(valid_url.is_some(), "A valid URL did not parse through from_str");
+
+    let invalid_url: Option<Url> = FromStr::from_str(":foo:example.com");
+    assert!(invalid_url.is_none(), "An inalid URL parsed through from_str");
 }
 
 struct Test {


### PR DESCRIPTION
This was supported in the old `url` package. We used it to import env-var based configuration into a variety of types.