### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rust implementation of the [URL Standard](http://url.spec.whatwg.org/).
 This is a replacement for Rust’s “old” (as of July 2014) `url` crate.
 See [Rust bug #10707](https://github.com/mozilla/rust/issues/10707).
 
-This buils with [Cargo](https://github.com/rust-lang/cargo),
+This builds with [Cargo](https://github.com/rust-lang/cargo),
 pulling in [rust-encoding](https://github.com/lifthrasiir/rust-encoding) as a depedency.
 
 [Documentation](http://servo.github.io/rust-url/url/index.html)


### PR DESCRIPTION
This changes the word `buils` in the readme to `builds`.
