### PR TITLE
Fixed range patterns

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -186,7 +186,7 @@ impl Ipv6Address {
                 let mut value = 0u16;
                 while i < len {
                     let digit = match input[i] {
-                        c @ b'0' .. b'9' => c - b'0',
+                        c @ b'0' ... b'9' => c - b'0',
                         _ => break
                     };
                     value = value * 10 + digit as u16;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -162,7 +162,7 @@ pub fn parse_scheme<'a>(input: &'a str, context: Context) -> Option<(String, &'a
     }
     for (i, c) in input.char_indices() {
         match c {
-            'a'..'z' | 'A'..'Z' | '0'..'9' | '+' | '-' | '.' => (),
+            'a'...'z' | 'A'...'Z' | '0'...'9' | '+' | '-' | '.' => (),
             ':' => return Some((
                 input.slice_to(i).to_ascii_lower(),
                 input.slice_from(i + 1),
@@ -429,7 +429,7 @@ pub fn parse_port<'a>(input: &'a str, scheme_type: SchemeType, parser: &UrlParse
     let mut end = input.len();
     for (i, c) in input.char_indices() {
         match c {
-            '0'..'9' => {
+            '0'...'9' => {
                 port = port * 10 + (c as u32 - '0' as u32);
                 if port > ::std::u16::MAX as u32 {
                     return Err(InvalidPort)
@@ -674,7 +674,7 @@ pub fn parse_fragment<'a>(input: &'a str, parser: &UrlParser) -> ParseResult<Str
 #[inline]
 pub fn starts_with_ascii_alpha(string: &str) -> bool {
     match string.char_at(0) {
-        'a'..'z' | 'A'..'Z' => true,
+        'a'...'z' | 'A'...'Z' => true,
         _ => false,
     }
 }
@@ -682,7 +682,7 @@ pub fn starts_with_ascii_alpha(string: &str) -> bool {
 #[inline]
 fn is_ascii_hex_digit(byte: u8) -> bool {
     match byte {
-        b'a'..b'f' | b'A'..b'F' | b'0'..b'9' => true,
+        b'a'...b'f' | b'A'...b'F' | b'0'...b'9' => true,
         _ => false,
     }
 }
@@ -697,20 +697,20 @@ fn starts_with_2_hex(input: &str) -> bool {
 #[inline]
 fn is_url_code_point(c: char) -> bool {
     match c {
-        'a'..'z' |
-        'A'..'Z' |
-        '0'..'9' |
+        'a'...'z' |
+        'A'...'Z' |
+        '0'...'9' |
         '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | '-' |
         '.' | '/' | ':' | ';' | '=' | '?' | '@' | '_' | '~' |
-        '\u00A0'..'\uD7FF' | '\uE000'..'\uFDCF' | '\uFDF0'..'\uFFFD' |
-        '\U00010000'..'\U0001FFFD' | '\U00020000'..'\U0002FFFD' |
-        '\U00030000'..'\U0003FFFD' | '\U00040000'..'\U0004FFFD' |
-        '\U00050000'..'\U0005FFFD' | '\U00060000'..'\U0006FFFD' |
-        '\U00070000'..'\U0007FFFD' | '\U00080000'..'\U0008FFFD' |
-        '\U00090000'..'\U0009FFFD' | '\U000A0000'..'\U000AFFFD' |
-        '\U000B0000'..'\U000BFFFD' | '\U000C0000'..'\U000CFFFD' |
-        '\U000D0000'..'\U000DFFFD' | '\U000E1000'..'\U000EFFFD' |
-        '\U000F0000'..'\U000FFFFD' | '\U00100000'..'\U0010FFFD' => true,
+        '\u00A0'...'\uD7FF' | '\uE000'...'\uFDCF' | '\uFDF0'...'\uFFFD' |
+        '\U00010000'...'\U0001FFFD' | '\U00020000'...'\U0002FFFD' |
+        '\U00030000'...'\U0003FFFD' | '\U00040000'...'\U0004FFFD' |
+        '\U00050000'...'\U0005FFFD' | '\U00060000'...'\U0006FFFD' |
+        '\U00070000'...'\U0007FFFD' | '\U00080000'...'\U0008FFFD' |
+        '\U00090000'...'\U0009FFFD' | '\U000A0000'...'\U000AFFFD' |
+        '\U000B0000'...'\U000BFFFD' | '\U000C0000'...'\U000CFFFD' |
+        '\U000D0000'...'\U000DFFFD' | '\U000E1000'...'\U000EFFFD' |
+        '\U000F0000'...'\U000FFFFD' | '\U00100000'...'\U0010FFFD' => true,
         _ => false
     }
 }

--- a/src/percent_encoding.rs
+++ b/src/percent_encoding.rs
@@ -140,9 +140,9 @@ pub fn lossy_utf8_percent_decode(input: &[u8]) -> String {
 #[inline]
 pub fn from_hex(byte: u8) -> Option<u8> {
     match byte {
-        b'0' .. b'9' => Some(byte - b'0'),  // 0..9
-        b'A' .. b'F' => Some(byte + 10 - b'A'),  // A..F
-        b'a' .. b'f' => Some(byte + 10 - b'a'),  // a..f
+        b'0' ... b'9' => Some(byte - b'0'),  // 0...9
+        b'A' ... b'F' => Some(byte + 10 - b'A'),  // A...F
+        b'a' ... b'f' => Some(byte + 10 - b'a'),  // a...f
         _ => None
     }
 }

--- a/src/punycode.rs
+++ b/src/punycode.rs
@@ -81,9 +81,9 @@ pub fn decode(input: &str) -> Option<Vec<char>> {
         // which gets added to i.
         loop {
             let digit = match byte {
-                byte @ 0x30 .. 0x39 => byte - 0x30 + 26,  // 0..9
-                byte @ 0x41 .. 0x5A => byte - 0x41,  // A..Z
-                byte @ 0x61 .. 0x7A => byte - 0x61,  // a..z
+                byte @ 0x30 ... 0x39 => byte - 0x30 + 26,  // 0...9
+                byte @ 0x41 ... 0x5A => byte - 0x41,  // A...Z
+                byte @ 0x61 ... 0x7A => byte - 0x61,  // a...z
                 _ => return None
             } as u32;
             if digit > (u32::MAX - i) / weight {
@@ -205,8 +205,8 @@ pub fn encode(input: &[char]) -> Option<String> {
 #[inline]
 fn value_to_digit(value: u32, output: &mut String) {
     let code_point = match value {
-        0 .. 25 => value + 0x61,  // a..z
-        26 .. 35 => value - 26 + 0x30,  // 0..9
+        0 ... 25 => value + 0x61,  // a...z
+        26 ... 35 => value - 26 + 0x30,  // 0...9
         _ => fail!()
     };
     unsafe { output.push_byte(code_point as u8) }


### PR DESCRIPTION
I tried to build a project where rust-url was one of the dependencies and got many errors like this:

```
Compiling url v0.1.0 (https://github.com/servo/rust-url#29f70a47)
/Users/janapetrova/.cargo/git/checkouts/rust-url-1e22af4233079a1e/master/src/host.rs:189:34: 189:36 error: expected `=>`, found `..`
/Users/janapetrova/.cargo/git/checkouts/rust-url-1e22af4233079a1e/master/src/host.rs:189                         c @ b'0' .. b'9' => c - b'0',
```

There was a PR is Rust not long ago, that breaks code: https://github.com/rust-lang/rust/pull/17584
So I changed range syntax to fix this problem.
