### PR TITLE
Added a method to serialize a Url to a path with a query string

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -37,7 +37,7 @@ impl<'a, T: Str + Show> Show for PathFormatter<'a, T> {
 
 pub struct PathWithQueryFormatter<'a, T:'a> {
     pub path: &'a [T],
-    pub query: &'a Option<String>,
+    pub query: Option<&'a str>,
 }
 
 impl<'a, T: Str + Show> Show for PathWithQueryFormatter<'a, T> {
@@ -45,7 +45,7 @@ impl<'a, T: Str + Show> Show for PathWithQueryFormatter<'a, T> {
         try!(PathFormatter {
             path: self.path.as_slice()
         }.fmt(formatter));
-        match *self.query {
+        match self.query {
             None => (),
             Some(ref query) => {
                 try!(formatter.write(b"?"));
@@ -157,7 +157,7 @@ mod tests {
         for &(ref path, ref query, result) in data.iter() {
             assert_eq!(PathWithQueryFormatter {
                 path: path.as_slice(),
-                query: query
+                query: query.as_ref().map(|s| s.as_slice())
             }.to_string(), result.to_string());
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -35,6 +35,26 @@ impl<'a, T: Str + Show> Show for PathFormatter<'a, T> {
     }
 }
 
+pub struct PathWithQueryFormatter<'a, T:'a> {
+    pub path: &'a [T],
+    pub query: &'a Option<String>,
+}
+
+impl<'a, T: Str + Show> Show for PathWithQueryFormatter<'a, T> {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), FormatError> {
+        try!(PathFormatter {
+            path: self.path.as_slice()
+        }.fmt(formatter));
+        match *self.query {
+            None => (),
+            Some(ref query) => {
+                try!(formatter.write(b"?"));
+                try!(formatter.write(query.as_bytes()));
+            }
+        };
+        Ok(())
+    }
+}
 
 /// Formatter and serializer for URL username and password data.
 pub struct UserInfoFormatter<'a> {
@@ -91,7 +111,7 @@ impl<'a> Show for UrlNoFragmentFormatter<'a> {
 #[cfg(test)]
 mod tests {
     use super::super::Url;
-    use super::{PathFormatter, UserInfoFormatter};
+    use super::{PathFormatter, PathWithQueryFormatter, UserInfoFormatter};
 
     #[test]
     fn path_formatting() {
@@ -123,6 +143,21 @@ mod tests {
             assert_eq!(UserInfoFormatter {
                 username: username,
                 password: password
+            }.to_string(), result.to_string());
+        }
+    }
+
+    #[test]
+    fn path_with_query_formatting() {
+        let data = [
+            (vec!["test", "path"], None, "/test/path"),
+            (vec!["test", "path"], Some("a=b".to_string()), "/test/path?a=b"),
+            (vec!["test", "path"], Some("a=b&c=d".to_string()), "/test/path?a=b&c=d"),
+                ];
+        for &(ref path, ref query, result) in data.iter() {
+            assert_eq!(PathWithQueryFormatter {
+                path: path.as_slice(),
+                query: query
             }.to_string(), result.to_string());
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,7 +727,7 @@ impl Url {
         self.relative_scheme_data().map( |scheme_data| 
                                           PathWithQueryFormatter {
                                               path: scheme_data.path.as_slice(),
-                                              query: &self.query
+                                              query: self.query.as_ref().map(|s| s.as_slice())
                                           }.to_string()
                                           )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub use percent_encoding::{
     PASSWORD_ENCODE_SET, USERNAME_ENCODE_SET, FORM_URLENCODED_ENCODE_SET, EncodeSet,
 };
 
-use format::{PathFormatter, UserInfoFormatter, UrlNoFragmentFormatter};
+use format::{PathFormatter, PathWithQueryFormatter, UserInfoFormatter, UrlNoFragmentFormatter};
 
 mod host;
 mod parser;
@@ -718,6 +718,20 @@ impl Url {
         self.relative_scheme_data().map(|scheme_data| scheme_data.serialize_path())
     }
 
+    /// If the URL is in a *relative scheme*, serialize its path and query string as a string.
+    ///
+    /// The returned string starts with a "/" slash, and components are separated by slashes.
+    /// A trailing slash represents an empty last component.
+    #[inline]
+    pub fn serialize_path_with_query(&self) -> Option<String> {
+        self.relative_scheme_data().map( |scheme_data| 
+                                          PathWithQueryFormatter {
+                                              path: scheme_data.path.as_slice(),
+                                              query: &self.query
+                                          }.to_string()
+                                          )
+    }
+
     /// Parse the URL’s query string, if any, as `application/x-www-form-urlencoded`
     /// and return a vector of (key, value) pairs.
     #[inline]
@@ -1007,3 +1021,4 @@ impl FromUrlPath for path::windows::Path {
         }
     }
 }
+


### PR DESCRIPTION
Intended for use by HTTP clients. The Hyper client currently calls serialize_path() when constructing its GET requests, but this discards the query string. I'm suggesting this new rust-url method so that Hyper can use it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/38)
<!-- Reviewable:end -->
