### PR TITLE
Fix for macro syntax change in rust on 2014-12-19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url"
-version = "0.2.5"
+version = "0.2.6"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "URL parser for Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -979,7 +979,7 @@ impl FromUrlPath for path::posix::Path {
             None => Err(()),  // Path contains a NUL byte
             Some(path) => {
                 debug_assert!(path.is_absolute(),
-                              "to_file_path() failed to produce an absolute Path")
+                              "to_file_path() failed to produce an absolute Path");
                 Ok(path)
             }
         }
@@ -1006,9 +1006,9 @@ impl FromUrlPath for path::windows::Path {
             None => Err(()),  // Path contains a NUL byte or invalid UTF-8
             Some(path) => {
                 debug_assert!(path.is_absolute(),
-                              "to_file_path() failed to produce an absolute Path")
+                              "to_file_path() failed to produce an absolute Path");
                 debug_assert!(path::windows::prefix(&path) == Some(path::windows::DiskPrefix),
-                              "to_file_path() failed to produce a Path with a disk prefix")
+                              "to_file_path() failed to produce a Path with a disk prefix");
                 Ok(path)
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,7 +22,7 @@ macro_rules! is_match(
     ($value:expr, $($pattern:pat)|+) => (
         match $value { $($pattern)|+ => true, _ => false }
     );
-)
+);
 
 
 pub type ParseResult<T> = Result<T, ParseError>;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -75,7 +75,7 @@ fn url_parsing() {
                 assert_eq!(username, expected_username);
                 assert_eq!(password, expected_password);
                 let host = host.serialize();
-                assert_eq!(host, expected_host)
+                assert_eq!(host, expected_host);
                 assert_eq!(port, expected_port);
                 assert_eq!(Some(format!("/{}", path.connect("/"))), expected_path);
             },


### PR DESCRIPTION
Fix syntax change.
