### PR TITLE
Public urlutils and check type in set_scheme

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ use encoding::EncodingOverride;
 mod encoding;
 mod host;
 mod parser;
-mod urlutils;
+pub mod urlutils;
 pub mod percent_encoding;
 pub mod form_urlencoded;
 pub mod punycode;
@@ -434,12 +434,19 @@ pub enum SchemeType {
     FileLike,
 }
 
-
 impl SchemeType {
     pub fn default_port(&self) -> Option<u16> {
         match self {
             &SchemeType::Relative(default_port) => Some(default_port),
             _ => None,
+        }
+    }
+    pub fn same_as(&self, other: SchemeType) -> bool {
+        match (self, other) {
+            (&SchemeType::NonRelative, SchemeType::NonRelative) => true,
+            (&SchemeType::Relative(_), SchemeType::Relative(_)) => true,
+            (&SchemeType::FileLike,    SchemeType::FileLike) => true,
+            _ => false
         }
     }
 }

--- a/src/urlutils.rs
+++ b/src/urlutils.rs
@@ -16,14 +16,13 @@ use percent_encoding::{utf8_percent_encode_to, USERNAME_ENCODE_SET, PASSWORD_ENC
 
 
 #[allow(dead_code)]
-struct UrlUtilsWrapper<'a> {
-    url: &'a mut Url,
-    parser: &'a UrlParser<'a>,
+pub struct UrlUtilsWrapper<'a> {
+    pub url: &'a mut Url,
+    pub parser: &'a UrlParser<'a>,
 }
 
-
 #[doc(hidden)]
-trait UrlUtils {
+pub trait UrlUtils {
     fn set_scheme(&mut self, input: &str) -> ParseResult<()>;
     fn set_username(&mut self, input: &str) -> ParseResult<()>;
     fn set_password(&mut self, input: &str) -> ParseResult<()>;
@@ -40,6 +39,9 @@ impl<'a> UrlUtils for UrlUtilsWrapper<'a> {
     fn set_scheme(&mut self, input: &str) -> ParseResult<()> {
         match ::parser::parse_scheme(input, Context::Setter) {
             Some((scheme, _)) => {
+                if self.parser.get_scheme_type(&self.url.scheme).same_as(self.parser.get_scheme_type(&scheme)) {
+                    return Err(ParseError::InvalidScheme);
+                }
                 self.url.scheme = scheme;
                 Ok(())
             },


### PR DESCRIPTION
Make urlutils public and disallow changing the scheme type to an incompatible type