### PR TITLE
Upgrade to rustc 1.0.0-dev (890293655 2015-02-28)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,7 +305,7 @@ fn parse_relative_url<'a>(input: &'a str, scheme: String, scheme_type: SchemeTyp
 
 
 fn skip_slashes<'a>(input: &'a str, parser: &UrlParser) -> ParseResult<&'a str> {
-    let first_non_slash = input.find(|&:c| !matches!(c, '/' | '\\')).unwrap_or(input.len());
+    let first_non_slash = input.find(|c| !matches!(c, '/' | '\\')).unwrap_or(input.len());
     if &input[..first_non_slash] != "//" {
         try!(parser.parse_error(ParseError::ExpectedTwoSlashes));
     }


### PR DESCRIPTION
Fixed error:
```
src/parser.rs:308:39: 308:42 error: obsolete syntax: `:`, `&mut:`, or `&:`
src/parser.rs:308     let first_non_slash = input.find(|&:c| !matches!(c, '/' | '\\')).unwrap_or(input.len());
                                                        ^~~
note: rely on inference instead
```