### PR TITLE
Reduce the number of unstable APIs used

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -54,7 +54,7 @@ fn parse_internal(input: &[u8], mut encoding_override: EncodingOverride, mut use
     let mut pairs = Vec::new();
     for piece in input.split(|&b| b == b'&') {
         if !piece.is_empty() {
-            let (name, value) = match piece.position_elem(&b'=') {
+            let (name, value) = match piece.iter().position(|b| *b == b'=') {
                 Some(position) => (&piece[..position], &piece[position + 1..]),
                 None => (piece, &[][..])
             };

--- a/src/format.rs
+++ b/src/format.rs
@@ -21,7 +21,7 @@ pub struct PathFormatter<'a, T:'a> {
     pub path: &'a [T]
 }
 
-impl<'a, T: Str + fmt::Display> fmt::Display for PathFormatter<'a, T> {
+impl<'a, T: fmt::Display> fmt::Display for PathFormatter<'a, T> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         if self.path.is_empty() {
             formatter.write_str("/")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ assert!(css_url.serialize() == "http://servo.github.io/rust-url/main.css".to_str
 */
 
 
-#![feature(core, std_misc, collections, old_path, path, os)]
+#![feature(core, std_misc, old_path, path, os)]
 
 extern crate "rustc-serialize" as rustc_serialize;
 


### PR DESCRIPTION
I was able to get rid of the `collections` feature entirely and it looks like one of the `core` features, `Str`, isn't necessary.