### PR TITLE
urlutils.rs - an empty password should be saved as None, not empty string

### DIFF
--- a/src/urlutils.rs
+++ b/src/urlutils.rs
@@ -65,6 +65,10 @@ impl<'a> UrlUtils for UrlUtilsWrapper<'a> {
     fn set_password(&mut self, input: &str) -> ParseResult<()> {
         match self.url.scheme_data {
             SchemeData::Relative(RelativeSchemeData { ref mut password, .. }) => {
+                if input.len() == 0 {
+                    *password = None;
+                    return Ok(());
+                }
                 let mut new_password = String::new();
                 utf8_percent_encode_to(input, PASSWORD_ENCODE_SET, &mut new_password);
                 *password = Some(new_password);


### PR DESCRIPTION
Right now, if I set a username and password, then I clear them, the url serialization would be http://:@example.com
Easily solved just by setting the password to None when the input is empty string.