### PR TITLE
Remove [#deprecated] attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,6 @@ use std::path::{Path, PathBuf};
 pub use host::{Host, Ipv6Address};
 pub use parser::{ErrorHandler, ParseResult, ParseError};
 
-#[deprecated = "Moved to the `percent_encoding` module"]
 pub use percent_encoding::{
     percent_decode, percent_decode_to, percent_encode, percent_encode_to,
     utf8_percent_encode, utf8_percent_encode_to, lossy_utf8_percent_decode,


### PR DESCRIPTION
Fixes error: stability attributes may not be used outside of the standard library in latest nightly (rustc 1.0.0-nightly (2baf34825 2015-04-21) (built 2015-04-22))