### PR TITLE
fix build on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -994,7 +994,7 @@ fn file_url_path_to_pathbuf(path: &[String]) -> Result<PathBuf, ()> {
         return Err(())
     }
     let mut string = prefix.to_string();
-    for path_part in path[1..] {
+    for path_part in path.iter().skip(1) {
         string.push('\\');
 
         // Currently non-unicode windows paths cannot be represented


### PR DESCRIPTION
fix for the compile error "\src\lib.rs:997:5: 1005:6 error: the trait `core::marker::Sized` is not implemented for the type `[collections::string::String]` [E0277]" on Windows