### PR TITLE
implement FromStr for Url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ extern crate matches;
 
 use std::fmt::{self, Formatter};
 use std::hash;
+use std::str;
 use std::path::{Path, PathBuf};
 
 pub use host::{Host, Ipv6Address};
@@ -239,6 +240,13 @@ impl hash::Hash for Url {
     }
 }
 
+impl str::FromStr for Url {
+    type Err = ParseError;
+
+    fn from_str(url: &str) -> ParseResult<Url> {
+        Url::parse(url)
+    }
+}
 
 /// A set of optional parameters for URL parsing.
 pub struct UrlParser<'a> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -280,3 +280,8 @@ fn new_directory_paths() {
                                       "bar".to_string(), "".to_string()][..]));
     }
 }
+
+#[test]
+fn from_str() {
+    assert!("http://testing.com/this".parse::<Url>().is_ok());
+}


### PR DESCRIPTION
This enables the use of the `parse()` method on `&str`

Fixes #18.