### PR TITLE
Fix #124 integer underflow in slicing base URL path components.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use std::ascii::AsciiExt;
+use std::cmp::max;
 use std::error::Error;
 use std::fmt::{self, Formatter};
 
@@ -284,7 +285,7 @@ fn parse_relative_url<'a>(input: &'a str, scheme: String, scheme_type: SchemeTyp
                     path: path
                 }), remaining)
             } else {
-                let base_path = &base.path[..base.path.len() - 1];
+                let base_path = &base.path[..max(base.path.len(), 1) - 1];
                 // Relative path state
                 let (path, remaining) = try!(parse_path(
                     base_path, input, Context::UrlParser, scheme_type, parser));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -291,3 +291,13 @@ fn new_directory_paths() {
 fn from_str() {
     assert!("http://testing.com/this".parse::<Url>().is_ok());
 }
+
+#[test]
+fn issue_124() {
+    let url: Url = "file:a".parse().unwrap();
+    assert_eq!(url.path().unwrap(), ["a"]);
+    let url: Url = "file:...".parse().unwrap();
+    assert_eq!(url.path().unwrap(), ["..."]);
+    let url: Url = "file:..".parse().unwrap();
+    assert_eq!(url.path().unwrap(), [""]);
+}


### PR DESCRIPTION
#124

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/125)
<!-- Reviewable:end -->
