### PR TITLE
Adjust set_query_from_pairs bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ extern crate serde;
 use std::fmt::{self, Formatter};
 use std::str;
 use std::path::{Path, PathBuf};
+use std::borrow::Borrow;
 
 #[cfg(feature="serde_serialization")]
 use std::str::FromStr;
@@ -744,7 +745,8 @@ impl Url {
     /// Serialize an iterator of (key, value) pairs as `application/x-www-form-urlencoded`
     /// and set it as the URL’s query string.
     #[inline]
-    pub fn set_query_from_pairs<'a, I: Iterator<Item = (&'a str, &'a str)>>(&mut self, pairs: I) {
+    pub fn set_query_from_pairs<I, K, V>(&mut self, pairs: I)
+    where I: IntoIterator, I::Item: Borrow<(K, V)>, K: AsRef<str>, V: AsRef<str> {
         self.query = Some(form_urlencoded::serialize(pairs));
     }
 


### PR DESCRIPTION
The bounds of `Url::set_query_from_pairs` now match the ones from `form_urlencoded::serialize`.
The previous bounds did not allow e.g. passing in slices or iterators thereof.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/129)
<!-- Reviewable:end -->
