### PR TITLE
Adds docs for form_urlencoded::parse

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -23,6 +23,9 @@ use percent_encoding::{percent_encode_to, percent_decode, FORM_URLENCODED_ENCODE
 /// into a vector of (name, value) pairs.
 ///
 /// Use `parse(input.as_bytes())` to parse a `&str` string.
+///
+/// The names and values are URL-decoded. For instance, `%23first=%25try%25` will be
+/// converted to `[("#first", "%try%")]`.
 #[inline]
 pub fn parse(input: &[u8]) -> Vec<(String, String)> {
     parse_internal(input, EncodingOverride::utf8(), false).unwrap()


### PR DESCRIPTION
Hello,

I found myself wondering if this function would actually decode the values, as opposed to just splitting on the `=` sign and making some validity checks. I would be nice to have docs just say that the names/values are decoded.

Best regards,
Conrad

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/130)
<!-- Reviewable:end -->
