### PR TITLE
Adds docs about query string decoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,9 @@ impl<'a> UrlParser<'a> {
 /// assert_eq!(query, Some("q=42".to_string()));
 /// assert_eq!(fragment, None);
 /// ```
+///
+/// The query string returned by `url::parse_path` can be decoded with
+/// `url::form_urlencoded::parse`.
 #[inline]
 pub fn parse_path(input: &str)
                   -> ParseResult<(Vec<String>, Option<String>, Option<String>)> {


### PR DESCRIPTION
Hello,

I was [looking](https://twitter.com/kleinespel/status/643462183783923712) for a library to decode a query string from a URL, when I hadn't realised `url::form_urlencoded::parse` did just that.

I hope this little doc addition makes things a bit more clear.

Best regards,
Conrad

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/131)
<!-- Reviewable:end -->
