### PR TITLE
Replace `Origin::UID(OpaqueOrigin)` with `Origin::Opaque`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url"
-version = "0.5.1"
+version = "0.6.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"
@@ -33,6 +33,5 @@ version = "0.6.1"
 optional = true
 
 [dependencies]
-uuid = "0.1.17"
 rustc-serialize = "0.3"
 matches = "0.1"

--- a/tests/origin.rs
+++ b/tests/origin.rs
@@ -1,0 +1,18 @@
+extern crate url;
+use url::{Url, Origin};
+
+#[test]
+fn test_origin_eq() {
+    let a = Url::parse("http://example.org").unwrap();
+    let b = Url::parse("http://mozilla.org").unwrap();
+    assert!(a.origin() != b.origin());
+    assert!(a.origin() == a.origin());
+    let c = Url::parse("file:///home/user/foobar/Documents/letter.odf").unwrap();
+    let d = Url::parse("file:///home/user/foobar/Images/holiday.png").unwrap();
+    let c_origin = c.origin();
+    assert!(c.origin() != d.origin());
+    assert!(c.origin() != c.origin());
+    assert!(c_origin != c_origin);
+    assert!(c_origin != c_origin.clone());
+    assert!(Origin::Opaque != Origin::Opaque);
+}


### PR DESCRIPTION
For a discussion see https://github.com/servo/rust-url/issues/144#issuecomment-159013627
Remove the `OpaqueOrigin` struct and the dependency on the uuid crate.

This is a breaking change.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/146)
<!-- Reviewable:end -->
