### PR TITLE
Use triple slash for documentation on Url::origin method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,7 +635,7 @@ impl Url {
         self.to_string()
     }
 
-    // Return the origin of this URL (https://url.spec.whatwg.org/#origin)
+    /// Return the origin of this URL (https://url.spec.whatwg.org/#origin)
     pub fn origin(&self) -> Origin {
         match &*self.scheme {
             "blob" => {


### PR DESCRIPTION
I was a dumb-dumb and didn't add an additional slash for rustdocs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/150)
<!-- Reviewable:end -->
