### PR TITLE
making uuid field on OpaqueOrigin public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub struct Url {
 
 /// Opaque identifier for URLs that have file or other schemes
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct OpaqueOrigin(Uuid);
+pub struct OpaqueOrigin(pub Uuid);
 
 #[cfg(feature="heap_size")]
 known_heap_size!(0, OpaqueOrigin);


### PR DESCRIPTION
by default, fields on tuple structs are private[1]. In this case, an instance of OpaqueOrigin is not very useful if the only field is private and there's no getter.

[1] https://github.com/rust-lang/rfcs/blob/master/text/0001-private-fields.md

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/159)
<!-- Reviewable:end -->
