### PR TITLE
Add a missing `SchemeType::` in doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,7 +415,7 @@ impl<'a> UrlParser<'a> {
     ///         "https" => SchemeType::Relative(443),
     ///         "ws" => SchemeType::Relative(80),
     ///         "wss" => SchemeType::Relative(443),
-    ///         _ => NonRelative,
+    ///         _ => SchemeType::NonRelative,
     ///     }
     /// }
     /// ```


### PR DESCRIPTION
What it says on the tin.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/161)
<!-- Reviewable:end -->
