### PR TITLE
Change return type of password_mut to Option<&mut Option<String>>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url"
-version = "0.5.5"
+version = "0.6.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,10 +736,11 @@ impl Url {
             scheme_data.password.as_ref().map(|password| password as &str))
     }
 
-    /// If the URL is in a *relative scheme*, return a mutable reference to its password, if any.
+    /// If the URL is in a *relative scheme*, return a mutable reference to its password field,
+    /// which is of type Option<String>.
     #[inline]
-    pub fn password_mut(&mut self) -> Option<&mut String> {
-        self.relative_scheme_data_mut().and_then(|scheme_data| scheme_data.password.as_mut())
+    pub fn password_mut(&mut self) -> Option<&mut Option<String>> {
+        self.relative_scheme_data_mut().map(|scheme_data| &mut scheme_data.password)
     }
 
     /// Percent-decode the URL’s password, if any.


### PR DESCRIPTION
This is necessary because by default, if the URL ':' delimiter was not found in the URL, then password_mut() would return None, causing a later mutation to the password field in RelativeSchemeData impossible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/169)
<!-- Reviewable:end -->
