### PR TITLE
Do not panic when parsing '.' in URL host: #166

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -58,6 +58,9 @@ impl Host {
         ][..]).is_some() {
             return Err(ParseError::InvalidDomainCharacter)
         }
+        if domain.is_empty() {
+            return Err(ParseError::RelativeUrlWithoutBase)
+        }
         match parse_ipv4addr(&domain[..]) {
             Ok(Some(ipv4addr)) => Ok(Host::Ipv4(ipv4addr)),
             Ok(None) => Ok(Host::Domain(domain.to_ascii_lowercase())),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ extern crate url;
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 use url::{Host, Url};
+use url::ParseError;
 
 #[test]
 fn new_file_paths() {
@@ -80,6 +81,10 @@ fn new_directory_paths() {
     if cfg!(unix) {
         assert_eq!(Url::from_directory_path(Path::new("relative")), Err(()));
         assert_eq!(Url::from_directory_path(Path::new("../relative")), Err(()));
+        assert_eq!(Url::parse("relative"), Err(ParseError::RelativeUrlWithoutBase));
+        assert_eq!(Url::parse("../relative"), Err(ParseError::RelativeUrlWithoutBase));
+        assert_eq!(Url::parse("./relative"), Err(ParseError::RelativeUrlWithoutBase));
+        assert_eq!(Url::parse("file://./foo"), Err(ParseError::RelativeUrlWithoutBase));
 
         let url = Url::from_directory_path(Path::new("/foo/bar")).unwrap();
         assert_eq!(url.host(), Some(&Host::Domain("".to_string())));


### PR DESCRIPTION
In response to #166. The parser should not panic when parsing URLs such as `file://./foo`.

Really this was just an excuse to dig into `rust-url` and learn more about it, so tips, comments, and critiques are welcomed!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/170)
<!-- Reviewable:end -->
