### PR TITLE
fixing handling of canonicalized path on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1084,6 +1084,7 @@ fn path_to_file_url_path_windows(path: &Path) -> Result<Vec<String>, ()> {
     let disk = match components.next() {
         Some(Component::Prefix(ref p)) => match p.kind() {
             Prefix::Disk(byte) => byte,
+            Prefix::VerbatimDisk(byte) => byte,
             _ => return Err(()),
         },
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -69,6 +69,10 @@ fn new_path_windows_fun() {
         // Invalid UTF-8
         url.path_mut().unwrap()[2] = "ba%80r".to_string();
         assert!(url.to_file_path().is_err());
+        
+        // test windows canonicalized path        
+        let path = PathBuf::from(r"\\?\C:\foo\bar");
+        assert!(Url::from_file_path(path).is_ok());
     }
 }
 


### PR DESCRIPTION
fixed the handling for paths in the form of "\\?\C:\..."
solves https://github.com/servo/rust-url/issues/184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/185)
<!-- Reviewable:end -->
