### PR TITLE
Make Cargo.toml compatible with TOML spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,16 @@ readme = "README.md"
 keywords = ["url", "parser"]
 license = "MIT/Apache-2.0"
 
-[[test]] name = "format"
-[[test]] name = "form_urlencoded"
-[[test]] name = "idna"
-[[test]] name = "punycode"
-[[test]] name = "tests"
+[[test]]
+name = "format"
+[[test]]
+name = "form_urlencoded"
+[[test]]
+name = "idna"
+[[test]]
+name = "punycode"
+[[test]]
+name = "tests"
 [[test]]
 name = "wpt"
 harness = false


### PR DESCRIPTION
Hello!

I think the Cargo.toml for this crate may not be strictly compliant with the TOML specification - I'm not certain, but it's blowing up in pytoml and my reading of the spec sides with pytoml.

The relevant part of the Cargo.toml file:

```
[[test]] name = "format"
```

And the [TOML spec on tables](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md#table):

> They appear in square brackets on a line by themselves

So I think pytoml is right to object here, but I'm fairly new to TOML so please let me know if I'm mis-interpreting and I'll go fix pytoml instead :)

The incompatibility with pytoml is an issue if you are using cargo-bootstrap, and I've tested that my proposed fix here fixes dhuseby/cargo-bootstrap#13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/186)
<!-- Reviewable:end -->
