### PR TITLE
Fixed AppVeyor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 rust-url
 ========
 
-[![Travis build Status](https://travis-ci.org/servo/rust-url.svg?branch=master)](https://travis-ci.org/servo/rust-url) [![Appveyor build status](https://ci.appveyor.com/api/projects/status/ulkqx2xcemyod6xa?svg=true)](https://ci.appveyor.com/project/Manishearth/rust-url)
+[![Travis build Status](https://travis-ci.org/servo/rust-url.svg?branch=master)](https://travis-ci.org/servo/rust-url) [![Appveyor build status](https://ci.appveyor.com/api/projects/status/ulkqx2xcemyod6xa?svg=true)](https://ci.appveyor.com/project/servo/rust-url)
 
 URL library for Rust, based on the [URL Standard](http://url.spec.whatwg.org/).
 


### PR DESCRIPTION
The actual badge URL is still wrong. I don't think this project is set up there since it was moved from Manishearth's acount to the servo organization, so maybe that needs fixing as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/191)
<!-- Reviewable:end -->
