### PR TITLE
Have Url::from_file_path not generate an URL with an empty path. Fix #197

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1243,11 +1243,17 @@ fn path_to_file_url_segments(path: &Path, serialization: &mut String) -> Result<
     if !path.is_absolute() {
         return Err(())
     }
+    let mut empty = true;
     // skip the root component
     for component in path.components().skip(1) {
+        empty = false;
         serialization.push('/');
         serialization.extend(percent_encode(
-            component.as_os_str().as_bytes(), PATH_SEGMENT_ENCODE_SET))
+            component.as_os_str().as_bytes(), PATH_SEGMENT_ENCODE_SET));
+    }
+    if empty {
+        // An URL’s path must not be empty.
+        serialization.push('/');
     }
     Ok(())
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -259,3 +259,12 @@ fn issue_61() {
     assert_eq!(url.port_or_known_default(), Some(443));
     url.assert_invariants();
 }
+
+#[test]
+/// https://github.com/servo/rust-url/issues/197
+fn issue_197() {
+    let mut url = Url::from_file_path("/").unwrap();
+    url.assert_invariants();
+    assert_eq!(url, Url::parse("file:///").unwrap());
+    url.path_segments_mut().unwrap().pop_if_empty();
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/198)
<!-- Reviewable:end -->
