### PR TITLE
Changes needed for gecko-integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rustc-serialize = "0.3"
 [features]
 query_encoding = ["encoding"]
 heap_size = ["heapsize", "heapsize_plugin"]
+only_percent_decode_hostname_valid = []
 
 [dependencies]
 idna = { version = "0.1.0", path = "./idna" }

--- a/src/host.rs
+++ b/src/host.rs
@@ -12,7 +12,7 @@ use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 use std::vec;
 use parser::{ParseResult, ParseError};
-use percent_encoding::percent_decode;
+use percent_encoding::percent_decode_hostname;
 use idna;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -77,10 +77,10 @@ impl Host<String> {
             }
             return parse_ipv6addr(&input[1..input.len() - 1]).map(Host::Ipv6)
         }
-        let domain = percent_decode(input.as_bytes()).decode_utf8_lossy();
+        let domain = percent_decode_hostname(input.as_bytes()).decode_utf8_lossy();
         let domain = try!(idna::domain_to_ascii(&domain));
         if domain.find(|c| matches!(c,
-            '\0' | '\t' | '\n' | '\r' | ' ' | '#' | '%' | '/' | ':' | '?' | '@' | '[' | '\\' | ']'
+            '\0' | '\t' | '\n' | '\r' | ' ' | '#' | '/' | ':' | '?' | '@' | '[' | '\\' | ']'
         )).is_some() {
             return Err(ParseError::InvalidDomainCharacter)
         }

--- a/src/slicing.rs
+++ b/src/slicing.rs
@@ -8,6 +8,7 @@
 
 use std::ops::{Range, RangeFrom, RangeTo, RangeFull, Index};
 use Url;
+use std::mem;
 
 impl Index<RangeFull> for Url {
     type Output = str;
@@ -77,6 +78,7 @@ impl Index<Range<Position>> for Url {
 /// `BeforeScheme` and `AfterFragment` are always the start and end of the entire URL,
 /// so `&url[BeforeScheme..X]` is the same as `&url[..X]`
 /// and `&url[X..AfterFragment]` is the same as `&url[X..]`.
+#[repr(u32)]
 #[derive(Copy, Clone, Debug)]
 pub enum Position {
     BeforeScheme,
@@ -95,6 +97,14 @@ pub enum Position {
     AfterQuery,
     BeforeFragment,
     AfterFragment
+}
+
+impl From<u32> for Position {
+    fn from(f: u32) -> Self {
+        unsafe {
+            mem::transmute(f)
+        }
+    }
 }
 
 impl Url {

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -268,3 +268,9 @@ fn issue_197() {
     assert_eq!(url, Url::parse("file:///").unwrap());
     url.path_segments_mut().unwrap().pop_if_empty();
 }
+
+#[test]
+#[cfg(feature = "only_percent_decode_hostname_valid")]
+fn test_percent_encoded_hostname() {
+    assert_eq!(Url::parse("http://example.com%0a%23.google.com/").unwrap().domain(), Some("example.com%0a%23.google.com"));
+}

--- a/tests/urltestdata.json
+++ b/tests/urltestdata.json
@@ -3514,11 +3514,6 @@
     "base": "http://other.com/",
     "failure": true
   },
-  {
-    "input": "http://hello%00",
-    "base": "http://other.com/",
-    "failure": true
-  },
   "Escaped numbers should be treated like IP addresses if they are.",
   {
     "input": "http://%30%78%63%30%2e%30%32%35%30.01",


### PR DESCRIPTION
This pull request contains 2 features that are needed in the C-API for use in Gecko:
1. Feature that allows to only percent decode characters that are valid in the hostname. 
This introduces the ```only_percent_decode_hostname_valid``` feature.
2. From<u32> for Position in order to use slicing in the C API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/201)
<!-- Reviewable:end -->
