### PR TITLE
Use HTTPS for README URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ rust-url
 
 [![Travis build Status](https://travis-ci.org/servo/rust-url.svg?branch=master)](https://travis-ci.org/servo/rust-url) [![Appveyor build status](https://ci.appveyor.com/api/projects/status/ulkqx2xcemyod6xa?svg=true)](https://ci.appveyor.com/project/Manishearth/rust-url)
 
-URL library for Rust, based on the [URL Standard](http://url.spec.whatwg.org/).
+URL library for Rust, based on the [URL Standard](https://url.spec.whatwg.org/).
 
-[Documentation](http://servo.github.io/rust-url/url/index.html)
+[Documentation](https://servo.github.io/rust-url/url/index.html)


### PR DESCRIPTION
Was using a public hotspot earlier today, clicked these links, and MITM ads appeared 😥.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/202)
<!-- Reviewable:end -->
