### PR TITLE
Handle empty domain segments correctly in idna

### DIFF
--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -224,10 +224,12 @@ fn processing(domain: &str, flags: Flags, errors: &mut Vec<Error>) -> String {
     }
     let normalized: String = mapped.nfc().collect();
     let mut validated = String::new();
+    let mut first = true;
     for label in normalized.split('.') {
-        if validated.len() > 0 {
+        if !first {
             validated.push('.');
         }
+        first = false;
         if label.starts_with("xn--") {
             match punycode::decode_to_string(&label["xn--".len()..]) {
                 Some(decoded_label) => {
@@ -273,10 +275,12 @@ pub struct Errors(Vec<Error>);
 pub fn to_ascii(domain: &str, flags: Flags) -> Result<String, Errors> {
     let mut errors = Vec::new();
     let mut result = String::new();
+    let mut first = true;
     for label in processing(domain, flags, &mut errors).split('.') {
-        if result.len() > 0 {
+        if !first {
             result.push('.');
         }
+        first = false;
         if label.is_ascii() {
             result.push_str(label);
         } else {

--- a/tests/urltestdata.json
+++ b/tests/urltestdata.json
@@ -4373,5 +4373,22 @@
     "search": "?qux",
     "searchParams": "",
     "hash": "#foo%08bar"
+  },
+  "# Correct handling of empty domain segments",
+  {
+    "input": "http://../",
+    "base": "about:blank",
+    "href": "http://../",
+    "origin": "http://..",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "..",
+    "hostname": "..",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "searchParams": "",
+    "hash": ""
   }
 ]


### PR DESCRIPTION
Spec asks us to "Otherwise join the labels using U+002E FULL STOP as a separator". The current code checking if the result was non-empty would fail if the segments themself were non-empty. It should be equivalent to `.split('.').map(.. processing ..).join('.')`. Implementing it procedurally since the code is already pretty procedural and it avoids extra allocations.


Should `processing()` return an iterator? We seem to be needlessly deconstructing and reconstructing the same string twice. OTOH that would mean more allocations.

r? @SimonSapin

fixes #255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/256)
<!-- Reviewable:end -->
