### PR TITLE
Make mod host public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,13 +143,13 @@ pub use parser::ParseError;
 pub use slicing::Position;
 
 mod encoding;
-mod host;
 mod origin;
 mod path_segments;
 mod parser;
 mod slicing;
 
 pub mod form_urlencoded;
+pub mod host;
 pub mod percent_encoding;
 pub mod quirks;
 


### PR DESCRIPTION
This just makes the mod public, so I can call into Host::parse() from rust_url_capi.
@Manishearth @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/265)
<!-- Reviewable:end -->
