### PR TITLE
add Url::parse_with_params()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url"
-version = "1.2.5"
+version = "1.3.0"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -112,6 +112,14 @@ fn from_str() {
 }
 
 #[test]
+fn parse_with_params() {
+    let url = Url::parse_with_params("http://testing.com/this?dont=clobberme",
+                                     &[("lang", "rust")]).unwrap();
+
+    assert_eq!(url.as_str(), "http://testing.com/this?dont=clobberme&lang=rust");
+}
+
+#[test]
 fn issue_124() {
     let url: Url = "file:a".parse().unwrap();
     assert_eq!(url.path(), "/a");


### PR DESCRIPTION
Allows us to build a `Url` from user-supplied params without the boilerplate of constructing then modifying the `Url`.

This is in hopes of improving the ergenomics of the reqwest library: https://github.com/seanmonstar/reqwest/pull/45#issuecomment-272589321

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/271)
<!-- Reviewable:end -->
