### PR TITLE
Add impl Serialize and Deserialize for Option<Url>

### DIFF
--- a/url_serde/Cargo.toml
+++ b/url_serde/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url_serde"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The rust-url developers"]
 
 description = "Serde support for URL types"
@@ -17,6 +17,7 @@ url = "1.0.0"
 
 [dev-dependencies]
 serde_json = "0.9.0"
+serde_derive = "0.9.0"
 
 [lib]
 doctest = false


### PR DESCRIPTION
This commit is adding impl Serialize and Deserialize for Option<Url>
which is intended to be used with serde serliaze_with and
deserialize_with for derived ser/deser when an url field is optional.

This commit is also adding some tests for derived Serialize and
Deserialize via serde serialize_with and deserialize_with, as
custom_derive is stable since rust 1.15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/279)
<!-- Reviewable:end -->
