### PR TITLE
Add fuzz scripts

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+
+target
+libfuzzer

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,15 @@
+
+[package]
+name = "url-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+
+[dependencies.url]
+path = ".."
+
+[[bin]]
+name = "parse"
+path = "fuzzers/parse.rs"
+
+[workspace]
+members = ["."]

--- a/fuzz/fuzzers/parse.rs
+++ b/fuzz/fuzzers/parse.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+extern crate fuzzer_sys;
+
+extern crate url;
+use std::slice;
+use std::str;
+
+#[export_name="LLVMFuzzerTestOneInput"]
+pub extern fn go(data: *const u8, size: isize) -> i32 {
+	let slice = unsafe { slice::from_raw_parts(data, size as usize) };
+	if let Ok(utf8) = str::from_utf8(slice) {
+		let url = url::Url::parse(utf8);
+	}
+	return 0;
+}


### PR DESCRIPTION
Add a simple script for fuzzing with https://github.com/rust-fuzz/cargo-fuzz

Mostly autogenerated by cargo-fuzz; the contents of `go()` in parser.rs were
manually written.

cargo-fuzz is still WIP so the format here may change.

This can be fuzzed (on Linux only) with `cargo fuzz --target parser`

r? @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/281)
<!-- Reviewable:end -->
