### PR TITLE
fuzzer_sys -> libfuzzer_sys

### DIFF
--- a/fuzz/fuzzers/parse.rs
+++ b/fuzz/fuzzers/parse.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-extern crate fuzzer_sys;
+extern crate libfuzzer_sys;
 
 extern crate url;
 use std::slice;


### PR DESCRIPTION
Running the fuzzing code fails right now. Changing the crate declaration to `extern crate libfuzzer_sys` makes it work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/288)
<!-- Reviewable:end -->
