### PR TITLE
Fixed passwords getting percent_encoded

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -16,7 +16,7 @@ use encoding::EncodingOverride;
 use host::{Host, HostInternal};
 use percent_encoding::{
     utf8_percent_encode, percent_encode,
-    SIMPLE_ENCODE_SET, DEFAULT_ENCODE_SET, USERINFO_ENCODE_SET, QUERY_ENCODE_SET,
+    SIMPLE_ENCODE_SET, DEFAULT_ENCODE_SET, QUERY_ENCODE_SET,
     PATH_SEGMENT_ENCODE_SET
 };
 
@@ -685,7 +685,7 @@ impl<'a> Parser<'a> {
                     }
                     last_at = Some((char_count, remaining.clone()))
                 },
-                '/' | '?' | '#' => break,
+                '/' => break,
                 '\\' if scheme_type.is_special() => break,
                 _ => (),
             }
@@ -707,7 +707,7 @@ impl<'a> Parser<'a> {
                 self.serialization.push(':');
             } else {
                 self.check_url_code_point(c, &input);
-                self.serialization.extend(utf8_percent_encode(utf8_c, USERINFO_ENCODE_SET));
+                self.serialization.extend((*utf8_c).chars().last());
             }
         }
         let username_end = match username_end {


### PR DESCRIPTION
When testing mysql database connectors, I came across this squirrelly response:

`thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidPort', /Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libcore/result.rs:86`

My connection string was similar to:

`mysql://root:pass#word@example.com`

Which immediately prompted me to wonder what was happening. I cloned the repo for the connector I was using and started debugging, before I dug deeper and found it was due to the url::Url type panicking. So I delved even deeper and ended up here.

I found that `parse_userinfo` was breaking at the `#`, which would then cause some errors downstream when parsing the rest of the url. 

After this fix, I found that the password, since it wasn't expecting these characters, was `percent_encoding` these characters, so the connection string would turn into:

`mysql://root:pass%23word@example.com`

My proposed change would allow additional special characters in the password, accepting the `?` and `#` characters that were previously disallowed. [IBM](https://www.ibm.com/support/knowledgecenter/en/SSAW57_8.5.5/com.ibm.websphere.nd.doc/ae/csec_chars.html) and [various](https://docs.oracle.com/cd/E11223_01/doc.910/e11197/app_special_char.htm#BABGCBGA) [others](https://www.owasp.org/index.php/Password_special_characters) promote the usage of specifically `#` and `?` in passwords, which is why I think those restrictions should be taken out. 

This is my first pull request, so please let me know if this was too much.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/292)
<!-- Reviewable:end -->
