### PR TITLE
Fixed parse_userinfo breaking with complex passwords

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -685,7 +685,7 @@ impl<'a> Parser<'a> {
                     }
                     last_at = Some((char_count, remaining.clone()))
                 },
-                '/' | '?' | '#' => break,
+                '/' => break,
                 '\\' if scheme_type.is_special() => break,
                 _ => (),
             }


### PR DESCRIPTION
Fixed the issue with my last pull request.

The problem with the `parse_userinfo` right now is that it breaks for a fragment delimiter or query string. That's all fine and dandy for further parsing functions, however, this check shouldn't be done with looking for the username and password, because these values can and will be used in passwords.

For example: `let url = Url::parse("mysql://root:pass#word@example.com");`

Results in: `thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidPort'` Due to the early break at the `#` sign.

After the change, the result is as expected: `mysql://root:pass%23word@example.com/`

Unless I'm mistaken, a fragment or query will never appear this early on in a url.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/293)
<!-- Reviewable:end -->