### PR TITLE
Add serde 1.0 support

### DIFF
--- a/url_serde/Cargo.toml
+++ b/url_serde/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "url_serde"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["The rust-url developers"]
 
 description = "Serde support for URL types"
@@ -12,12 +12,12 @@ keywords = ["url", "serde"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-serde = "0.9.0"
+serde = "1.0"
 url = "1.0.0"
 
 [dev-dependencies]
-serde_json = "0.9.0"
-serde_derive = "0.9.0"
+serde_json = "1.0"
+serde_derive = "1.0"
 
 [lib]
 doctest = false

--- a/url_serde/README.md
+++ b/url_serde/README.md
@@ -4,6 +4,8 @@ Serde support for rust-url types
 This crate provides wrappers and convenience functions to make `rust-url` and `serde`
 work hand in hand.
 
-This crate supports `serde 0.9.0` or newer. Older versions of `serde` are natively supported by `rust-url` crate directly.
+Version `0.2` or newer of this crate offer support for `serde 1.0`.
+Version `0.1` of this crate offer support for `serde 0.9`.
+Versions of `serde` older than `0.9` are natively supported by `rust-url` crate directly.
 
 For more details, see the crate [documentation](https://docs.rs/url_serde/).


### PR DESCRIPTION
This commit is adding support for serde 1.0 and update docs
to address #282.

Fix #282
Fix #295 

Note1: I had to bump the version of `url_serde` to `0.2` as the changes are not backward compatible and will cause custom derive to fail if the users are using `serde 0.9`.

Note2: I have decided not to use `remote-derive` serde feature for now. I will look into it more and maybe to another PR later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/296)
<!-- Reviewable:end -->
