### PR TITLE
Update serde dependency to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ test = false
 [dev-dependencies]
 rustc-test = "0.1"
 rustc-serialize = "0.3"
-serde_json = ">=0.6.1, <0.9"
+serde_json = "1.0"
 
 [features]
 query_encoding = ["encoding"]
@@ -39,4 +39,4 @@ heapsize = {version = ">=0.1.1, <0.4", optional = true}
 idna = { version = "0.1.0", path = "./idna" }
 matches = "0.1"
 rustc-serialize = {version = "0.3", optional = true}
-serde = {version = ">=0.6.1, <0.9", optional = true}
+serde = {version = "1.0", optional = true}

--- a/src/host.rs
+++ b/src/host.rs
@@ -29,7 +29,7 @@ known_heap_size!(0, HostInternal);
 
 #[cfg(feature="serde")]
 impl ::serde::Serialize for HostInternal {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: ::serde::Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
         // This doesn’t use `derive` because that involves
         // large dependencies (that take a long time to build), and
         // either Macros 1.1 which are not stable yet or a cumbersome build script.
@@ -47,8 +47,10 @@ impl ::serde::Serialize for HostInternal {
 }
 
 #[cfg(feature="serde")]
-impl ::serde::Deserialize for HostInternal {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error> where D: ::serde::Deserializer {
+impl<'de> ::serde::Deserialize<'de> for HostInternal {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: ::serde::Deserializer<'de>
+    {
         use std::net::IpAddr;
         Ok(match try!(::serde::Deserialize::deserialize(deserializer)) {
             None => HostInternal::None,
@@ -91,7 +93,7 @@ pub enum Host<S=String> {
 
 #[cfg(feature="serde")]
 impl<S: ::serde::Serialize>  ::serde::Serialize for Host<S> {
-    fn serialize<R>(&self, serializer: &mut R) -> Result<(), R::Error> where R: ::serde::Serializer {
+    fn serialize<R>(&self, serializer: R) -> Result<R::Ok, R::Error> where R: ::serde::Serializer {
         use std::net::IpAddr;
         match *self {
             Host::Domain(ref s) => Ok(s),
@@ -102,8 +104,12 @@ impl<S: ::serde::Serialize>  ::serde::Serialize for Host<S> {
 }
 
 #[cfg(feature="serde")]
-impl<S: ::serde::Deserialize> ::serde::Deserialize for Host<S> {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error> where D: ::serde::Deserializer {
+impl<'de, S> ::serde::Deserialize<'de> for Host<S>
+    where for <'des> S: ::serde::Deserialize<'des>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: ::serde::Deserializer<'de>
+    {
         use std::net::IpAddr;
         Ok(match try!(::serde::Deserialize::deserialize(deserializer)) {
             Ok(s) => Host::Domain(s),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1506,7 +1506,7 @@ impl Url {
     /// This method is only available if the `serde` Cargo feature is enabled.
     #[cfg(feature = "serde")]
     #[deny(unused)]
-    pub fn serialize_internal<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: serde::Serializer {
+    pub fn serialize_internal<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         use serde::Serialize;
         // Destructuring first lets us ensure that adding or removing fields forces this method
         // to be updated
@@ -1528,8 +1528,10 @@ impl Url {
     /// This method is only available if the `serde` Cargo feature is enabled.
     #[cfg(feature = "serde")]
     #[deny(unused)]
-    pub fn deserialize_internal<D>(deserializer: &mut D) -> Result<Self, D::Error> where D: serde::Deserializer {
-        use serde::{Deserialize, Error};
+    pub fn deserialize_internal<'de, D>(deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>
+    {
+        use serde::de::{Deserialize, Error};
         let (serialization, scheme_end, username_end,
              host_start, host_end, host, port, path_start,
              query_start, fragment_start) = try!(Deserialize::deserialize(deserializer));
@@ -1546,7 +1548,7 @@ impl Url {
             fragment_start: fragment_start
         };
         if cfg!(debug_assertions) {
-            try!(url.check_invariants().map_err(|ref reason| Error::invalid_value(&reason)))
+            try!(url.check_invariants().map_err(|ref reason| Error::custom(&reason)))
         }
         Ok(url)
     }
@@ -1718,7 +1720,7 @@ impl rustc_serialize::Decodable for Url {
 /// This implementation is only available if the `serde` Cargo feature is enabled.
 #[cfg(feature="serde")]
 impl serde::Serialize for Url {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: serde::Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         serializer.serialize_str(self.as_str())
     }
 }
@@ -1727,11 +1729,13 @@ impl serde::Serialize for Url {
 ///
 /// This implementation is only available if the `serde` Cargo feature is enabled.
 #[cfg(feature="serde")]
-impl serde::Deserialize for Url {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Url, D::Error> where D: serde::Deserializer {
+impl<'de> serde::Deserialize<'de> for Url {
+    fn deserialize<D>(deserializer: D) -> Result<Url, D::Error>
+        where D: serde::Deserializer<'de>
+    {
         let string_representation: String = try!(serde::Deserialize::deserialize(deserializer));
         Url::parse(&string_representation).map_err(|err| {
-            serde::Error::invalid_value(err.description())
+            serde::de::Error::custom(err.description())
         })
     }
 }


### PR DESCRIPTION
These changes updates `serde` dependency from `0.9` to `1.0` line.
Only root sources updated (no updates in sub-crates).
I added lifetimes to `Deserialize` trait implementations and use ownership instead of mutable reference.
Also I used associated types for results.

I see that there is #296, but that PR updates `url_serde` only (that's why I haven't updated sub-crates).

I've runned/passed all tests and checked it as dependency for my own project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/297)
<!-- Reviewable:end -->
#