### PR TITLE
Add a test that define_encode_set works inside both modules and funct…

### DIFF
--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -8,6 +8,7 @@
 
 //! Unit tests
 
+#[macro_use]
 extern crate url;
 
 use std::borrow::Cow;
@@ -341,4 +342,33 @@ fn test_set_host() {
     let mut url = Url::parse("foobar://example.net/hello").unwrap();
     url.set_host(None).unwrap();
     assert_eq!(url.as_str(), "foobar:/hello");
+}
+
+// This is testing that the macro produces buildable code when invoked
+// inside both a module and a function
+#[test]
+fn define_encode_set_scopes() {
+    use url::percent_encoding::{utf8_percent_encode, SIMPLE_ENCODE_SET};
+
+    define_encode_set! {
+        /// This encode set is used in the URL parser for query strings.
+        pub QUERY_ENCODE_SET = [SIMPLE_ENCODE_SET] | {' ', '"', '#', '<', '>'}
+    }
+
+    assert_eq!(utf8_percent_encode("foo bar", QUERY_ENCODE_SET).collect::<String>(), "foo%20bar");
+
+    mod m {
+        use url::percent_encoding::{utf8_percent_encode, SIMPLE_ENCODE_SET};
+
+        define_encode_set! {
+            /// This encode set is used in the URL parser for query strings.
+            pub QUERY_ENCODE_SET = [SIMPLE_ENCODE_SET] | {' ', '"', '#', '<', '>'}
+        }
+
+        pub fn test() {
+            assert_eq!(utf8_percent_encode("foo bar", QUERY_ENCODE_SET).collect::<String>(), "foo%20bar");
+        }
+    }
+
+    m::test();
 }


### PR DESCRIPTION
[Guidelines](https://github.com/brson/rust-api-guidelines#macros) say to ensure item macros work in both positions, and I couldn't tell, so I added a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/306)
<!-- Reviewable:end -->
