### PR TITLE
Implement `Hash` for `Origin` (fix #302)

### DIFF
--- a/src/origin.rs
+++ b/src/origin.rs
@@ -50,7 +50,7 @@ pub fn url_origin(url: &Url) -> Origin {
 ///   the URL does not have the same origin as any other URL.
 ///
 /// For more information see https://url.spec.whatwg.org/#origin
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Origin {
     /// A globally unique identifier
     Opaque(OpaqueOrigin),
@@ -123,7 +123,7 @@ impl Origin {
 }
 
 /// Opaque identifier for URLs that have file or other schemes
-#[derive(Eq, PartialEq, Clone, Debug)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct OpaqueOrigin(usize);
 
 #[cfg(feature = "heapsize")]


### PR DESCRIPTION
Hello,

I'm a Rust / Open Source beginner, so just explain if anything is wrong. :-)

I am giving a try at issue #302. I just derived the `Hash` for the `Origin` type.

I have zero experience with testing in Rust so I just tried to demonstrate that it works, but I do not know how to write a good test for this.

What should I do now?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/321)
<!-- Reviewable:end -->
