### PR TITLE
Replace unwrap() in doctests with `?`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,11 @@ Let’s parse a valid URL and look at its components.
 
 ```
 use url::{Url, Host};
-
+# use url::ParseError;
+# fn run() -> Result<(), ParseError> {
 let issue_list_url = Url::parse(
     "https://github.com/rust-lang/rust/issues?labels=E-easy&state=open"
-).unwrap();
+)?;
 
 
 assert!(issue_list_url.scheme() == "https");
@@ -44,6 +45,8 @@ assert!(issue_list_url.path_segments().map(|c| c.collect::<Vec<_>>()) ==
 assert!(issue_list_url.query() == Some("labels=E-easy&state=open"));
 assert!(issue_list_url.fragment() == None);
 assert!(!issue_list_url.cannot_be_a_base());
+# Ok(())
+# }
 ```
 
 Some URLs are said to be *cannot-be-a-base*:
@@ -52,8 +55,10 @@ and their "path" is an arbitrary string rather than slash-separated segments:
 
 ```
 use url::Url;
+# use url::ParseError;
 
-let data_url = Url::parse("data:text/plain,Hello?World#").unwrap();
+# fn run() -> Result<(), ParseError> {
+let data_url = Url::parse("data:text/plain,Hello?World#")?;
 
 assert!(data_url.cannot_be_a_base());
 assert!(data_url.scheme() == "data");
@@ -61,6 +66,8 @@ assert!(data_url.path() == "text/plain,Hello");
 assert!(data_url.path_segments().is_none());
 assert!(data_url.query() == Some("World"));
 assert!(data_url.fragment() == Some(""));
+# Ok(())
+# }
 ```
 
 
@@ -84,10 +91,14 @@ Use the `join` method on an `Url` to use it as a base URL:
 
 ```
 use url::Url;
+# use url::ParseError;
 
-let this_document = Url::parse("http://servo.github.io/rust-url/url/index.html").unwrap();
-let css_url = this_document.join("../main.css").unwrap();
-assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css")
+# fn run() -> Result<(), ParseError> {
+let this_document = Url::parse("http://servo.github.io/rust-url/url/index.html")?;
+let css_url = this_document.join("../main.css")?;
+assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css");
+# Ok(())
+# }
 */
 
 #[cfg(feature="rustc-serialize")] extern crate rustc_serialize;
@@ -218,8 +229,12 @@ impl Url {
     ///
     /// ```rust
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("https://example.net").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("https://example.net")?;
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn parse(input: &str) -> Result<Url, ::ParseError> {
@@ -234,9 +249,13 @@ impl Url {
     ///
     /// ```rust
     /// use url::Url;
+    /// # use url::ParseError;
     ///
+    /// # fn run() -> Result<(), ParseError> {
     /// let url = Url::parse_with_params("https://example.net?dont=clobberme",
-    ///                                  &[("lang", "rust"), ("browser", "servo")]);
+    ///                                  &[("lang", "rust"), ("browser", "servo")])?;
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn parse_with_params<I, K, V>(input: &str, iter: I) -> Result<Url, ::ParseError>
@@ -264,14 +283,18 @@ impl Url {
     ///
     /// ```rust
     /// use url::Url;
-    ///
-    /// let base = Url::parse("https://example.net/a/b.html").unwrap();
-    /// let url = base.join("c.png").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let base = Url::parse("https://example.net/a/b.html")?;
+    /// let url = base.join("c.png")?;
     /// assert_eq!(url.as_str(), "https://example.net/a/c.png");  // Not /a/b.html/c.png
     ///
-    /// let base = Url::parse("https://example.net/a/b/").unwrap();
-    /// let url = base.join("c.png").unwrap();
+    /// let base = Url::parse("https://example.net/a/b/")?;
+    /// let url = base.join("c.png")?;
     /// assert_eq!(url.as_str(), "https://example.net/a/b/c.png");
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn join(&self, input: &str) -> Result<Url, ::ParseError> {
@@ -295,10 +318,14 @@ impl Url {
     ///
     /// ```rust
     /// use url::Url;
+    /// # use url::ParseError;
     ///
+    /// # fn run() -> Result<(), ParseError> {
     /// let url_str = "https://example.net/";
-    /// let url = Url::parse(url_str).unwrap();
+    /// let url = Url::parse(url_str)?;
     /// assert_eq!(url.as_str(), url_str);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn as_str(&self) -> &str {
@@ -313,10 +340,14 @@ impl Url {
     ///
     /// ```rust
     /// use url::Url;
+    /// # use url::ParseError;
     ///
+    /// # fn run() -> Result<(), ParseError> {
     /// let url_str = "https://example.net/";
-    /// let url = Url::parse(url_str).unwrap();
+    /// let url = Url::parse(url_str)?;
     /// assert_eq!(url.into_string(), url_str);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn into_string(self) -> String {
@@ -442,45 +473,61 @@ impl Url {
     ///
     /// ```rust
     /// use url::{Host, Origin, Url};
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("ftp://example.com/foo").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("ftp://example.com/foo")?;
     /// assert_eq!(url.origin(),
     ///            Origin::Tuple("ftp".into(),
     ///                          Host::Domain("example.com".into()),
     ///                          21));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// URL with `blob` scheme:
     ///
     /// ```rust
     /// use url::{Host, Origin, Url};
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("blob:https://example.com/foo").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("blob:https://example.com/foo")?;
     /// assert_eq!(url.origin(),
     ///            Origin::Tuple("https".into(),
     ///                          Host::Domain("example.com".into()),
     ///                          443));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// URL with `file` scheme:
     ///
     /// ```rust
     /// use url::{Host, Origin, Url};
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("file:///tmp/foo").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("file:///tmp/foo")?;
     /// assert!(!url.origin().is_tuple());
     ///
-    /// let other_url = Url::parse("file:///tmp/foo").unwrap();
+    /// let other_url = Url::parse("file:///tmp/foo")?;
     /// assert!(url.origin() != other_url.origin());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// URL with other scheme:
     ///
     /// ```rust
     /// use url::{Host, Origin, Url};
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("foo:bar").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("foo:bar")?;
     /// assert!(!url.origin().is_tuple());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn origin(&self) -> Origin {
@@ -493,9 +540,13 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("file:///tmp/foo").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("file:///tmp/foo")?;
     /// assert_eq!(url.scheme(), "file");
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn scheme(&self) -> &str {
@@ -512,15 +563,19 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert!(url.has_authority());
     ///
-    /// let url = Url::parse("unix:/run/foo.socket").unwrap();
+    /// let url = Url::parse("unix:/run/foo.socket")?;
     /// assert!(!url.has_authority());
     ///
-    /// let url = Url::parse("data:text/plain,Stuff").unwrap();
+    /// let url = Url::parse("data:text/plain,Stuff")?;
     /// assert!(!url.has_authority());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn has_authority(&self) -> bool {
@@ -538,15 +593,19 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert!(!url.cannot_be_a_base());
     ///
-    /// let url = Url::parse("unix:/run/foo.socket").unwrap();
+    /// let url = Url::parse("unix:/run/foo.socket")?;
     /// assert!(!url.cannot_be_a_base());
     ///
-    /// let url = Url::parse("data:text/plain,Stuff").unwrap();
+    /// let url = Url::parse("data:text/plain,Stuff")?;
     /// assert!(url.cannot_be_a_base());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn cannot_be_a_base(&self) -> bool {
@@ -560,15 +619,19 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert_eq!(url.username(), "rms");
     ///
-    /// let url = Url::parse("ftp://:secret123@example.com").unwrap();
+    /// let url = Url::parse("ftp://:secret123@example.com")?;
     /// assert_eq!(url.username(), "");
     ///
-    /// let url = Url::parse("https://example.com").unwrap();
+    /// let url = Url::parse("https://example.com")?;
     /// assert_eq!(url.username(), "");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn username(&self) -> &str {
         if self.has_authority() {
@@ -584,18 +647,22 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("ftp://rms:secret123@example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("ftp://rms:secret123@example.com")?;
     /// assert_eq!(url.password(), Some("secret123"));
     ///
-    /// let url = Url::parse("ftp://:secret123@example.com").unwrap();
+    /// let url = Url::parse("ftp://:secret123@example.com")?;
     /// assert_eq!(url.password(), Some("secret123"));
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert_eq!(url.password(), None);
     ///
-    /// let url = Url::parse("https://example.com").unwrap();
+    /// let url = Url::parse("https://example.com")?;
     /// assert_eq!(url.password(), None);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn password(&self) -> Option<&str> {
         // This ':' is not the one marking a port number since a host can not be empty.
@@ -614,15 +681,19 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert!(url.has_host());
     ///
-    /// let url = Url::parse("unix:/run/foo.socket").unwrap();
+    /// let url = Url::parse("unix:/run/foo.socket")?;
     /// assert!(!url.has_host());
     ///
-    /// let url = Url::parse("data:text/plain,Stuff").unwrap();
+    /// let url = Url::parse("data:text/plain,Stuff")?;
     /// assert!(!url.has_host());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn has_host(&self) -> bool {
         !matches!(self.host, HostInternal::None)
@@ -642,18 +713,22 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("https://127.0.0.1/index.html").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("https://127.0.0.1/index.html")?;
     /// assert_eq!(url.host_str(), Some("127.0.0.1"));
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert_eq!(url.host_str(), Some("example.com"));
     ///
-    /// let url = Url::parse("unix:/run/foo.socket").unwrap();
+    /// let url = Url::parse("unix:/run/foo.socket")?;
     /// assert_eq!(url.host_str(), None);
     ///
-    /// let url = Url::parse("data:text/plain,Stuff").unwrap();
+    /// let url = Url::parse("data:text/plain,Stuff")?;
     /// assert_eq!(url.host_str(), None);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn host_str(&self) -> Option<&str> {
         if self.has_host() {
@@ -675,18 +750,22 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("https://127.0.0.1/index.html").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("https://127.0.0.1/index.html")?;
     /// assert!(url.host().is_some());
     ///
-    /// let url = Url::parse("ftp://rms@example.com").unwrap();
+    /// let url = Url::parse("ftp://rms@example.com")?;
     /// assert!(url.host().is_some());
     ///
-    /// let url = Url::parse("unix:/run/foo.socket").unwrap();
+    /// let url = Url::parse("unix:/run/foo.socket")?;
     /// assert!(url.host().is_none());
     ///
-    /// let url = Url::parse("data:text/plain,Stuff").unwrap();
+    /// let url = Url::parse("data:text/plain,Stuff")?;
     /// assert!(url.host().is_none());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn host(&self) -> Option<Host<&str>> {
         match self.host {
@@ -703,15 +782,19 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("https://127.0.0.1/").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("https://127.0.0.1/")?;
     /// assert_eq!(url.domain(), None);
     ///
-    /// let url = Url::parse("mailto:rms@example.net").unwrap();
+    /// let url = Url::parse("mailto:rms@example.net")?;
     /// assert_eq!(url.domain(), None);
     ///
-    /// let url = Url::parse("https://example.com/").unwrap();
+    /// let url = Url::parse("https://example.com/")?;
     /// assert_eq!(url.domain(), Some("example.com"));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn domain(&self) -> Option<&str> {
         match self.host {
@@ -726,12 +809,16 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("https://example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("https://example.com")?;
     /// assert_eq!(url.port(), None);
     ///
-    /// let url = Url::parse("ssh://example.com:22").unwrap();
+    /// let url = Url::parse("ssh://example.com:22")?;
     /// assert_eq!(url.port(), Some(22));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn port(&self) -> Option<u16> {
@@ -750,15 +837,19 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("foo://example.com").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("foo://example.com")?;
     /// assert_eq!(url.port_or_known_default(), None);
     ///
-    /// let url = Url::parse("foo://example.com:1456").unwrap();
+    /// let url = Url::parse("foo://example.com:1456")?;
     /// assert_eq!(url.port_or_known_default(), Some(1456));
     ///
-    /// let url = Url::parse("https://example.com").unwrap();
+    /// let url = Url::parse("https://example.com")?;
     /// assert_eq!(url.port_or_known_default(), Some(443));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn port_or_known_default(&self) -> Option<u16> {
@@ -834,20 +925,24 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let url = Url::parse("https://example.com/foo/bar").unwrap();
-    /// let mut path_segments = url.path_segments().unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("https://example.com/foo/bar")?;
+    /// let mut path_segments = url.path_segments().expect("not a cannot-be-a-base URL");
     /// assert_eq!(path_segments.next(), Some("foo"));
     /// assert_eq!(path_segments.next(), Some("bar"));
     /// assert_eq!(path_segments.next(), None);
     ///
-    /// let url = Url::parse("https://example.com").unwrap();
-    /// let mut path_segments = url.path_segments().unwrap();
+    /// let url = Url::parse("https://example.com")?;
+    /// let mut path_segments = url.path_segments().expect("not a cannot-be-a-base URL");
     /// assert_eq!(path_segments.next(), Some(""));
     /// assert_eq!(path_segments.next(), None);
     ///
-    /// let url = Url::parse("data:text/plain,HelloWorld").unwrap();
+    /// let url = Url::parse("data:text/plain,HelloWorld")?;
     /// assert!(url.path_segments().is_none());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn path_segments(&self) -> Option<str::Split<char>> {
         let path = self.path();
@@ -959,8 +1054,10 @@ impl Url {
     /// The return value has a method-chaining API:
     ///
     /// ```rust
-    /// # use url::Url;
-    /// let mut url = Url::parse("https://example.net?lang=fr#nav").unwrap();
+    /// # use url::{Url, ParseError};
+    ///
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://example.net?lang=fr#nav")?;
     /// assert_eq!(url.query(), Some("lang=fr"));
     ///
     /// url.query_pairs_mut().append_pair("foo", "bar");
@@ -974,6 +1071,8 @@ impl Url {
     /// assert_eq!(url.query(), Some("foo=bar+%26+baz&saisons=%C3%89t%C3%A9%2Bhiver"));
     /// assert_eq!(url.as_str(),
     ///            "https://example.net/?foo=bar+%26+baz&saisons=%C3%89t%C3%A9%2Bhiver#nav");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Note: `url.query_pairs_mut().clear();` is equivalent to `url.set_query(Some(""))`,
@@ -1061,28 +1160,36 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let mut url = Url::parse("ssh://example.net:2048/").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("ssh://example.net:2048/")?;
     ///
-    /// url.set_port(Some(4096)).unwrap();
+    /// url.set_port(Some(4096)).expect("not a cannot-be-a-base URL");
     /// assert_eq!(url.as_str(), "ssh://example.net:4096/");
     ///
-    /// url.set_port(None).unwrap();
+    /// url.set_port(None).expect("not a cannot-be-a-base URL");
     /// assert_eq!(url.as_str(), "ssh://example.net/");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Cannot set port for cannot-be-a-base URLs:
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let mut url = Url::parse("mailto:rms@example.net").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("mailto:rms@example.net")?;
     ///
     /// let result = url.set_port(Some(80));
     /// assert!(result.is_err());
     ///
     /// let result = url.set_port(None);
     /// assert!(result.is_err());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_port(&mut self, mut port: Option<u16>) -> Result<(), ()> {
         if !self.has_host() || self.scheme() == "file" {
@@ -1139,41 +1246,55 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
+    /// # use url::ParseError;
     ///
-    /// let mut url = Url::parse("https://example.net").unwrap();
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_host(Some("rust-lang.org"));
     /// assert!(result.is_ok());
     /// assert_eq!(url.as_str(), "https://rust-lang.org/");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Remove host:
     ///
     /// ```
     /// use url::Url;
-    ///
-    /// let mut url = Url::parse("foo://example.net").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("foo://example.net")?;
     /// let result = url.set_host(None);
     /// assert!(result.is_ok());
     /// assert_eq!(url.as_str(), "foo:/");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Cannot remove host for 'special' schemes (e.g. `http`):
     ///
     /// ```
     /// use url::Url;
-    ///
-    /// let mut url = Url::parse("https://example.net").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_host(None);
     /// assert!(result.is_err());
     /// assert_eq!(url.as_str(), "https://example.net/");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Cannot change or remove host for cannot-be-a-base URLs:
     ///
     /// ```
     /// use url::Url;
-    ///
-    /// let mut url = Url::parse("mailto:rms@example.net").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("mailto:rms@example.net")?;
     ///
     /// let result = url.set_host(Some("rust-lang.org"));
     /// assert!(result.is_err());
@@ -1182,6 +1303,8 @@ impl Url {
     /// let result = url.set_host(None);
     /// assert!(result.is_err());
     /// assert_eq!(url.as_str(), "mailto:rms@example.net");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_host(&mut self, host: Option<&str>) -> Result<(), ParseError> {
         if self.cannot_be_a_base() {
@@ -1376,11 +1499,15 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
-    ///
-    /// let mut url = Url::parse("https://example.net").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_scheme("foo");
     /// assert_eq!(url.as_str(), "foo://example.net/");
     /// assert!(result.is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     ///
@@ -1388,22 +1515,30 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
-    ///
-    /// let mut url = Url::parse("https://example.net").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_scheme("foõ");
     /// assert_eq!(url.as_str(), "https://example.net/");
     /// assert!(result.is_err());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Cannot change URL’s scheme from `mailto` (cannot-be-a-base) to `https`:
     ///
     /// ```
     /// use url::Url;
-    ///
-    /// let mut url = Url::parse("mailto:rms@example.net").unwrap();
+    /// # use url::ParseError;
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("mailto:rms@example.net")?;
     /// let result = url.set_scheme("https");
     /// assert_eq!(url.as_str(), "mailto:rms@example.net");
     /// assert!(result.is_err());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_scheme(&mut self, scheme: &str) -> Result<(), ()> {
         let mut parser = Parser::for_setter(String::new());
@@ -1444,8 +1579,9 @@ impl Url {
     /// ```
     /// # if cfg!(unix) {
     /// use url::Url;
-    ///
-    /// let url = Url::from_file_path("/tmp/foo.txt").unwrap();
+    /// 
+    /// # fn run() -> Result<(), ()> {
+    /// let url = Url::from_file_path("/tmp/foo.txt")?;
     /// assert_eq!(url.as_str(), "file:///tmp/foo.txt");
     ///
     /// let url = Url::from_file_path("../foo.txt");
@@ -1453,6 +1589,8 @@ impl Url {
     ///
     /// let url = Url::from_file_path("https://google.com/");
     /// assert!(url.is_err());
+    /// # Ok(())
+    /// # }
     /// # }
     /// ```
     pub fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -870,9 +870,8 @@ impl Url {
     /// # use url::Url;
     /// # use std::net::TcpStream;
     /// # use std::io;
-    ///
     /// fn connect(url: &Url) -> io::Result<TcpStream> {
-    ///     TcpStream::connect(try!(url.with_default_port(default_port)))
+    ///     TcpStream::connect(url.with_default_port(default_port)?)
     /// }
     ///
     /// fn default_port(url: &Url) -> Result<u16, ()> {
@@ -925,17 +924,29 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
-    /// # use url::ParseError;
+    /// use std::error::Error;
+    /// use std::fmt;
     ///
-    /// # fn run() -> Result<(), ParseError> {
+    /// #[derive(Debug)]
+    /// struct CannotBeBaseError;
+    /// impl fmt::Display for CannotBeBaseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         f.write_str(self.description())
+    ///     }
+    /// }
+    /// impl Error for CannotBeBaseError {
+    ///     fn description(&self) -> &str { "cannot be a base" }
+    /// }
+    ///
+    /// # fn run() -> Result<(), Box<Error>> {
     /// let url = Url::parse("https://example.com/foo/bar")?;
-    /// let mut path_segments = url.path_segments().expect("not a cannot-be-a-base URL");
+    /// let mut path_segments = url.path_segments().ok_or_else(|| CannotBeBaseError)?;
     /// assert_eq!(path_segments.next(), Some("foo"));
     /// assert_eq!(path_segments.next(), Some("bar"));
     /// assert_eq!(path_segments.next(), None);
     ///
     /// let url = Url::parse("https://example.com")?;
-    /// let mut path_segments = url.path_segments().expect("not a cannot-be-a-base URL");
+    /// let mut path_segments = url.path_segments().ok_or_else(|| CannotBeBaseError)?;
     /// assert_eq!(path_segments.next(), Some(""));
     /// assert_eq!(path_segments.next(), None);
     ///
@@ -1160,15 +1171,27 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
-    /// # use url::ParseError;
+    /// use std::error::Error;
+    /// use std::fmt;
     ///
-    /// # fn run() -> Result<(), ParseError> {
+    /// #[derive(Debug)]
+    /// struct CannotBeBaseError;
+    /// impl fmt::Display for CannotBeBaseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         f.write_str(self.description())
+    ///     }
+    /// }
+    /// impl Error for CannotBeBaseError {
+    ///     fn description(&self) -> &str { "cannot be a base" }
+    /// }
+    ///
+    /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("ssh://example.net:2048/")?;
     ///
-    /// url.set_port(Some(4096)).expect("not a cannot-be-a-base URL");
+    /// url.set_port(Some(4096)).map_err(|_| CannotBeBaseError)?;
     /// assert_eq!(url.as_str(), "ssh://example.net:4096/");
     ///
-    /// url.set_port(None).expect("not a cannot-be-a-base URL");
+    /// url.set_port(None).map_err(|_| CannotBeBaseError)?;
     /// assert_eq!(url.as_str(), "ssh://example.net/");
     /// # Ok(())
     /// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -924,29 +924,17 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
-    /// use std::error::Error;
-    /// use std::fmt;
-    ///
-    /// #[derive(Debug)]
-    /// struct CannotBeBaseError;
-    /// impl fmt::Display for CannotBeBaseError {
-    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    ///         f.write_str(self.description())
-    ///     }
-    /// }
-    /// impl Error for CannotBeBaseError {
-    ///     fn description(&self) -> &str { "cannot be a base" }
-    /// }
+    /// # use std::error::Error;
     ///
     /// # fn run() -> Result<(), Box<Error>> {
     /// let url = Url::parse("https://example.com/foo/bar")?;
-    /// let mut path_segments = url.path_segments().ok_or_else(|| CannotBeBaseError)?;
+    /// let mut path_segments = url.path_segments().ok_or_else(|| "cannot be base")?;
     /// assert_eq!(path_segments.next(), Some("foo"));
     /// assert_eq!(path_segments.next(), Some("bar"));
     /// assert_eq!(path_segments.next(), None);
     ///
     /// let url = Url::parse("https://example.com")?;
-    /// let mut path_segments = url.path_segments().ok_or_else(|| CannotBeBaseError)?;
+    /// let mut path_segments = url.path_segments().ok_or_else(|| "cannot be base")?;
     /// assert_eq!(path_segments.next(), Some(""));
     /// assert_eq!(path_segments.next(), None);
     ///
@@ -1171,27 +1159,15 @@ impl Url {
     ///
     /// ```
     /// use url::Url;
-    /// use std::error::Error;
-    /// use std::fmt;
-    ///
-    /// #[derive(Debug)]
-    /// struct CannotBeBaseError;
-    /// impl fmt::Display for CannotBeBaseError {
-    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    ///         f.write_str(self.description())
-    ///     }
-    /// }
-    /// impl Error for CannotBeBaseError {
-    ///     fn description(&self) -> &str { "cannot be a base" }
-    /// }
+    /// # use std::error::Error;
     ///
     /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("ssh://example.net:2048/")?;
     ///
-    /// url.set_port(Some(4096)).map_err(|_| CannotBeBaseError)?;
+    /// url.set_port(Some(4096)).map_err(|_| "cannot be base")?;
     /// assert_eq!(url.as_str(), "ssh://example.net:4096/");
     ///
-    /// url.set_port(None).map_err(|_| CannotBeBaseError)?;
+    /// url.set_port(None).map_err(|_| "cannot be base")?;
     /// assert_eq!(url.as_str(), "ssh://example.net/");
     /// # Ok(())
     /// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ assert!(issue_list_url.fragment() == None);
 assert!(!issue_list_url.cannot_be_a_base());
 # Ok(())
 # }
+# run().unwrap();
 ```
 
 Some URLs are said to be *cannot-be-a-base*:
@@ -68,6 +69,7 @@ assert!(data_url.query() == Some("World"));
 assert!(data_url.fragment() == Some(""));
 # Ok(())
 # }
+# run().unwrap();
 ```
 
 
@@ -99,6 +101,7 @@ let css_url = this_document.join("../main.css")?;
 assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css");
 # Ok(())
 # }
+# run().unwrap();
 */
 
 #[cfg(feature="rustc-serialize")] extern crate rustc_serialize;
@@ -235,6 +238,7 @@ impl Url {
     /// let url = Url::parse("https://example.net")?;
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn parse(input: &str) -> Result<Url, ::ParseError> {
@@ -256,6 +260,7 @@ impl Url {
     ///                                  &[("lang", "rust"), ("browser", "servo")])?;
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn parse_with_params<I, K, V>(input: &str, iter: I) -> Result<Url, ::ParseError>
@@ -295,6 +300,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "https://example.net/a/b/c.png");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn join(&self, input: &str) -> Result<Url, ::ParseError> {
@@ -326,6 +332,7 @@ impl Url {
     /// assert_eq!(url.as_str(), url_str);
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn as_str(&self) -> &str {
@@ -348,6 +355,7 @@ impl Url {
     /// assert_eq!(url.into_string(), url_str);
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn into_string(self) -> String {
@@ -483,6 +491,7 @@ impl Url {
     ///                          21));
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// URL with `blob` scheme:
@@ -499,6 +508,7 @@ impl Url {
     ///                          443));
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// URL with `file` scheme:
@@ -515,6 +525,7 @@ impl Url {
     /// assert!(url.origin() != other_url.origin());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// URL with other scheme:
@@ -528,6 +539,7 @@ impl Url {
     /// assert!(!url.origin().is_tuple());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn origin(&self) -> Origin {
@@ -547,6 +559,7 @@ impl Url {
     /// assert_eq!(url.scheme(), "file");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn scheme(&self) -> &str {
@@ -576,6 +589,7 @@ impl Url {
     /// assert!(!url.has_authority());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn has_authority(&self) -> bool {
@@ -606,6 +620,7 @@ impl Url {
     /// assert!(url.cannot_be_a_base());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn cannot_be_a_base(&self) -> bool {
@@ -632,6 +647,7 @@ impl Url {
     /// assert_eq!(url.username(), "");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn username(&self) -> &str {
         if self.has_authority() {
@@ -663,6 +679,7 @@ impl Url {
     /// assert_eq!(url.password(), None);
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn password(&self) -> Option<&str> {
         // This ':' is not the one marking a port number since a host can not be empty.
@@ -694,6 +711,7 @@ impl Url {
     /// assert!(!url.has_host());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn has_host(&self) -> bool {
         !matches!(self.host, HostInternal::None)
@@ -729,6 +747,7 @@ impl Url {
     /// assert_eq!(url.host_str(), None);
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn host_str(&self) -> Option<&str> {
         if self.has_host() {
@@ -766,6 +785,7 @@ impl Url {
     /// assert!(url.host().is_none());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn host(&self) -> Option<Host<&str>> {
         match self.host {
@@ -795,6 +815,7 @@ impl Url {
     /// assert_eq!(url.domain(), Some("example.com"));
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn domain(&self) -> Option<&str> {
         match self.host {
@@ -819,6 +840,7 @@ impl Url {
     /// assert_eq!(url.port(), Some(22));
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn port(&self) -> Option<u16> {
@@ -850,6 +872,7 @@ impl Url {
     /// assert_eq!(url.port_or_known_default(), Some(443));
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     #[inline]
     pub fn port_or_known_default(&self) -> Option<u16> {
@@ -942,6 +965,7 @@ impl Url {
     /// assert!(url.path_segments().is_none());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn path_segments(&self) -> Option<str::Split<char>> {
         let path = self.path();
@@ -1072,6 +1096,7 @@ impl Url {
     ///            "https://example.net/?foo=bar+%26+baz&saisons=%C3%89t%C3%A9%2Bhiver#nav");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// Note: `url.query_pairs_mut().clear();` is equivalent to `url.set_query(Some(""))`,
@@ -1171,6 +1196,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "ssh://example.net/");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// Cannot set port for cannot-be-a-base URLs:
@@ -1189,6 +1215,7 @@ impl Url {
     /// assert!(result.is_err());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn set_port(&mut self, mut port: Option<u16>) -> Result<(), ()> {
         if !self.has_host() || self.scheme() == "file" {
@@ -1254,6 +1281,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "https://rust-lang.org/");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// Remove host:
@@ -1269,6 +1297,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "foo:/");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// Cannot remove host for 'special' schemes (e.g. `http`):
@@ -1284,6 +1313,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "https://example.net/");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// Cannot change or remove host for cannot-be-a-base URLs:
@@ -1304,6 +1334,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "mailto:rms@example.net");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn set_host(&mut self, host: Option<&str>) -> Result<(), ParseError> {
         if self.cannot_be_a_base() {
@@ -1507,6 +1538,7 @@ impl Url {
     /// assert!(result.is_ok());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     ///
@@ -1523,6 +1555,7 @@ impl Url {
     /// assert!(result.is_err());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// Cannot change URL’s scheme from `mailto` (cannot-be-a-base) to `https`:
@@ -1538,6 +1571,7 @@ impl Url {
     /// assert!(result.is_err());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn set_scheme(&mut self, scheme: &str) -> Result<(), ()> {
         let mut parser = Parser::for_setter(String::new());
@@ -1590,6 +1624,7 @@ impl Url {
     /// assert!(url.is_err());
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// # }
     /// ```
     pub fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -18,13 +18,17 @@ use Url;
 /// Examples:
 ///
 /// ```rust
-/// # use url::Url;
-/// let mut url = Url::parse("mailto:me@example.com").unwrap();
+/// # use url::{Url, ParseError};
+///
+/// # fn run() -> Result<(), ParseError> {
+/// let mut url = Url::parse("mailto:me@example.com")?;
 /// assert!(url.path_segments_mut().is_err());
 ///
-/// let mut url = Url::parse("http://example.net/foo/index.html").unwrap();
+/// let mut url = Url::parse("http://example.net/foo/index.html")?;
 /// url.path_segments_mut().unwrap().pop().push("img").push("2/100%.png");
 /// assert_eq!(url.as_str(), "http://example.net/foo/img/2%2F100%25.png");
+/// # Ok(())
+/// # }
 /// ```
 pub struct PathSegmentsMut<'a> {
     url: &'a mut Url,
@@ -60,10 +64,14 @@ impl<'a> PathSegmentsMut<'a> {
     /// Example:
     ///
     /// ```rust
-    /// # use url::Url;
-    /// let mut url = Url::parse("https://github.com/servo/rust-url/").unwrap();
+    /// # use url::{Url, ParseError};
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
     /// url.path_segments_mut().unwrap().clear().push("logout");
     /// assert_eq!(url.as_str(), "https://github.com/logout");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn clear(&mut self) -> &mut Self {
         self.url.serialization.truncate(self.after_first_slash);
@@ -81,14 +89,18 @@ impl<'a> PathSegmentsMut<'a> {
     /// Example:
     ///
     /// ```rust
-    /// # use url::Url;
-    /// let mut url = Url::parse("https://github.com/servo/rust-url/").unwrap();
+    /// # use url::{Url, ParseError};
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
     /// url.path_segments_mut().unwrap().push("pulls");
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url//pulls");
     ///
-    /// let mut url = Url::parse("https://github.com/servo/rust-url/").unwrap();
+    /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
     /// url.path_segments_mut().unwrap().pop_if_empty().push("pulls");
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn pop_if_empty(&mut self) -> &mut Self {
         if self.url.serialization[self.after_first_slash..].ends_with('/') {
@@ -138,23 +150,31 @@ impl<'a> PathSegmentsMut<'a> {
     /// Example:
     ///
     /// ```rust
-    /// # use url::Url;
-    /// let mut url = Url::parse("https://github.com/").unwrap();
+    /// # use url::{Url, ParseError};
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://github.com/")?;
     /// let org = "servo";
     /// let repo = "rust-url";
     /// let issue_number = "188";
     /// url.path_segments_mut().unwrap().extend(&[org, repo, "issues", issue_number]);
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/issues/188");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// In order to make sure that parsing the serialization of an URL gives the same URL,
     /// a segment is ignored if it is `"."` or `".."`:
     ///
     /// ```rust
-    /// # use url::Url;
-    /// let mut url = Url::parse("https://github.com/servo").unwrap();
+    /// # use url::{Url, ParseError};
+    /// 
+    /// # fn run() -> Result<(), ParseError> {
+    /// let mut url = Url::parse("https://github.com/servo")?;
     /// url.path_segments_mut().unwrap().extend(&["..", "rust-url", ".", "pulls"]);
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn extend<I>(&mut self, segments: I) -> &mut Self
     where I: IntoIterator, I::Item: AsRef<str> {

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -18,14 +18,28 @@ use Url;
 /// Examples:
 ///
 /// ```rust
-/// # use url::{Url, ParseError};
+/// use url::Url;
+/// use std::error::Error;
+/// use std::fmt;
 ///
-/// # fn run() -> Result<(), ParseError> {
+/// #[derive(Debug)]
+/// struct CannotBeBaseError;
+/// impl fmt::Display for CannotBeBaseError {
+///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+///         f.write_str(self.description())
+///     }
+/// }
+/// impl Error for CannotBeBaseError {
+///     fn description(&self) -> &str { "cannot be a base" }
+/// }
+///
+/// # fn run() -> Result<(), Box<Error>> {
 /// let mut url = Url::parse("mailto:me@example.com")?;
 /// assert!(url.path_segments_mut().is_err());
 ///
 /// let mut url = Url::parse("http://example.net/foo/index.html")?;
-/// url.path_segments_mut().unwrap().pop().push("img").push("2/100%.png");
+/// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+///     .pop().push("img").push("2/100%.png");
 /// assert_eq!(url.as_str(), "http://example.net/foo/img/2%2F100%25.png");
 /// # Ok(())
 /// # }
@@ -64,11 +78,25 @@ impl<'a> PathSegmentsMut<'a> {
     /// Example:
     ///
     /// ```rust
-    /// # use url::{Url, ParseError};
-    /// 
-    /// # fn run() -> Result<(), ParseError> {
+    /// use url::Url;
+    /// use std::error::Error;
+    /// use std::fmt;
+    ///
+    /// #[derive(Debug)]
+    /// struct CannotBeBaseError;
+    /// impl fmt::Display for CannotBeBaseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         f.write_str(self.description())
+    ///     }
+    /// }
+    /// impl Error for CannotBeBaseError {
+    ///     fn description(&self) -> &str { "cannot be a base" }
+    /// }
+    ///
+    /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
-    /// url.path_segments_mut().unwrap().clear().push("logout");
+    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    ///     .clear().push("logout");
     /// assert_eq!(url.as_str(), "https://github.com/logout");
     /// # Ok(())
     /// # }
@@ -90,14 +118,29 @@ impl<'a> PathSegmentsMut<'a> {
     ///
     /// ```rust
     /// # use url::{Url, ParseError};
-    /// 
-    /// # fn run() -> Result<(), ParseError> {
+    /// use std::error::Error;
+    /// use std::fmt;
+    ///
+    /// #[derive(Debug)]
+    /// struct CannotBeBaseError;
+    /// impl fmt::Display for CannotBeBaseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         f.write_str(self.description())
+    ///     }
+    /// }
+    /// impl Error for CannotBeBaseError {
+    ///     fn description(&self) -> &str { "cannot be a base" }
+    /// }
+    ///
+    /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
-    /// url.path_segments_mut().unwrap().push("pulls");
+    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    ///     .push("pulls");
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url//pulls");
     ///
     /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
-    /// url.path_segments_mut().unwrap().pop_if_empty().push("pulls");
+    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    ///     .pop_if_empty().push("pulls");
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
     /// # Ok(())
     /// # }
@@ -150,14 +193,28 @@ impl<'a> PathSegmentsMut<'a> {
     /// Example:
     ///
     /// ```rust
-    /// # use url::{Url, ParseError};
-    /// 
-    /// # fn run() -> Result<(), ParseError> {
+    /// use url::Url;
+    /// use std::error::Error;
+    /// use std::fmt;
+    ///
+    /// #[derive(Debug)]
+    /// struct CannotBeBaseError;
+    /// impl fmt::Display for CannotBeBaseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         f.write_str(self.description())
+    ///     }
+    /// }
+    /// impl Error for CannotBeBaseError {
+    ///     fn description(&self) -> &str { "cannot be a base" }
+    /// }
+    ///
+    /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/")?;
     /// let org = "servo";
     /// let repo = "rust-url";
     /// let issue_number = "188";
-    /// url.path_segments_mut().unwrap().extend(&[org, repo, "issues", issue_number]);
+    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    ///     .extend(&[org, repo, "issues", issue_number]);
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/issues/188");
     /// # Ok(())
     /// # }
@@ -167,11 +224,25 @@ impl<'a> PathSegmentsMut<'a> {
     /// a segment is ignored if it is `"."` or `".."`:
     ///
     /// ```rust
-    /// # use url::{Url, ParseError};
-    /// 
-    /// # fn run() -> Result<(), ParseError> {
+    /// use url::Url;
+    /// use std::error::Error;
+    /// use std::fmt;
+    ///
+    /// #[derive(Debug)]
+    /// struct CannotBeBaseError;
+    /// impl fmt::Display for CannotBeBaseError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         f.write_str(self.description())
+    ///     }
+    /// }
+    /// impl Error for CannotBeBaseError {
+    ///     fn description(&self) -> &str { "cannot be a base" }
+    /// }
+    ///
+    /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/servo")?;
-    /// url.path_segments_mut().unwrap().extend(&["..", "rust-url", ".", "pulls"]);
+    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    ///     .extend(&["..", "rust-url", ".", "pulls"]);
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
     /// # Ok(())
     /// # }

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -19,26 +19,14 @@ use Url;
 ///
 /// ```rust
 /// use url::Url;
-/// use std::error::Error;
-/// use std::fmt;
-///
-/// #[derive(Debug)]
-/// struct CannotBeBaseError;
-/// impl fmt::Display for CannotBeBaseError {
-///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-///         f.write_str(self.description())
-///     }
-/// }
-/// impl Error for CannotBeBaseError {
-///     fn description(&self) -> &str { "cannot be a base" }
-/// }
+/// # use std::error::Error;
 ///
 /// # fn run() -> Result<(), Box<Error>> {
 /// let mut url = Url::parse("mailto:me@example.com")?;
 /// assert!(url.path_segments_mut().is_err());
 ///
 /// let mut url = Url::parse("http://example.net/foo/index.html")?;
-/// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+/// url.path_segments_mut().map_err(|_| "cannot be base")?
 ///     .pop().push("img").push("2/100%.png");
 /// assert_eq!(url.as_str(), "http://example.net/foo/img/2%2F100%25.png");
 /// # Ok(())
@@ -79,23 +67,11 @@ impl<'a> PathSegmentsMut<'a> {
     ///
     /// ```rust
     /// use url::Url;
-    /// use std::error::Error;
-    /// use std::fmt;
-    ///
-    /// #[derive(Debug)]
-    /// struct CannotBeBaseError;
-    /// impl fmt::Display for CannotBeBaseError {
-    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    ///         f.write_str(self.description())
-    ///     }
-    /// }
-    /// impl Error for CannotBeBaseError {
-    ///     fn description(&self) -> &str { "cannot be a base" }
-    /// }
+    /// # use std::error::Error;
     ///
     /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
-    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    /// url.path_segments_mut().map_err(|_| "cannot be base")?
     ///     .clear().push("logout");
     /// assert_eq!(url.as_str(), "https://github.com/logout");
     /// # Ok(())
@@ -117,29 +93,17 @@ impl<'a> PathSegmentsMut<'a> {
     /// Example:
     ///
     /// ```rust
-    /// # use url::{Url, ParseError};
-    /// use std::error::Error;
-    /// use std::fmt;
-    ///
-    /// #[derive(Debug)]
-    /// struct CannotBeBaseError;
-    /// impl fmt::Display for CannotBeBaseError {
-    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    ///         f.write_str(self.description())
-    ///     }
-    /// }
-    /// impl Error for CannotBeBaseError {
-    ///     fn description(&self) -> &str { "cannot be a base" }
-    /// }
+    /// use url::Url;
+    /// # use std::error::Error;
     ///
     /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
-    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    /// url.path_segments_mut().map_err(|_| "cannot be base")?
     ///     .push("pulls");
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url//pulls");
     ///
     /// let mut url = Url::parse("https://github.com/servo/rust-url/")?;
-    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    /// url.path_segments_mut().map_err(|_| "cannot be base")?
     ///     .pop_if_empty().push("pulls");
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
     /// # Ok(())
@@ -194,26 +158,14 @@ impl<'a> PathSegmentsMut<'a> {
     ///
     /// ```rust
     /// use url::Url;
-    /// use std::error::Error;
-    /// use std::fmt;
-    ///
-    /// #[derive(Debug)]
-    /// struct CannotBeBaseError;
-    /// impl fmt::Display for CannotBeBaseError {
-    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    ///         f.write_str(self.description())
-    ///     }
-    /// }
-    /// impl Error for CannotBeBaseError {
-    ///     fn description(&self) -> &str { "cannot be a base" }
-    /// }
+    /// # use std::error::Error;
     ///
     /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/")?;
     /// let org = "servo";
     /// let repo = "rust-url";
     /// let issue_number = "188";
-    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    /// url.path_segments_mut().map_err(|_| "cannot be base")?
     ///     .extend(&[org, repo, "issues", issue_number]);
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/issues/188");
     /// # Ok(())
@@ -225,23 +177,11 @@ impl<'a> PathSegmentsMut<'a> {
     ///
     /// ```rust
     /// use url::Url;
-    /// use std::error::Error;
-    /// use std::fmt;
-    ///
-    /// #[derive(Debug)]
-    /// struct CannotBeBaseError;
-    /// impl fmt::Display for CannotBeBaseError {
-    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    ///         f.write_str(self.description())
-    ///     }
-    /// }
-    /// impl Error for CannotBeBaseError {
-    ///     fn description(&self) -> &str { "cannot be a base" }
-    /// }
+    /// # use std::error::Error;
     ///
     /// # fn run() -> Result<(), Box<Error>> {
     /// let mut url = Url::parse("https://github.com/servo")?;
-    /// url.path_segments_mut().map_err(|_| CannotBeBaseError)?
+    /// url.path_segments_mut().map_err(|_| "cannot be base")?
     ///     .extend(&["..", "rust-url", ".", "pulls"]);
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
     /// # Ok(())

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -31,6 +31,7 @@ use Url;
 /// assert_eq!(url.as_str(), "http://example.net/foo/img/2%2F100%25.png");
 /// # Ok(())
 /// # }
+/// # run().unwrap();
 /// ```
 pub struct PathSegmentsMut<'a> {
     url: &'a mut Url,
@@ -76,6 +77,7 @@ impl<'a> PathSegmentsMut<'a> {
     /// assert_eq!(url.as_str(), "https://github.com/logout");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn clear(&mut self) -> &mut Self {
         self.url.serialization.truncate(self.after_first_slash);
@@ -108,6 +110,7 @@ impl<'a> PathSegmentsMut<'a> {
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn pop_if_empty(&mut self) -> &mut Self {
         if self.url.serialization[self.after_first_slash..].ends_with('/') {
@@ -170,6 +173,7 @@ impl<'a> PathSegmentsMut<'a> {
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/issues/188");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     ///
     /// In order to make sure that parsing the serialization of an URL gives the same URL,
@@ -186,6 +190,7 @@ impl<'a> PathSegmentsMut<'a> {
     /// assert_eq!(url.as_str(), "https://github.com/servo/rust-url/pulls");
     /// # Ok(())
     /// # }
+    /// # run().unwrap();
     /// ```
     pub fn extend<I>(&mut self, segments: I) -> &mut Self
     where I: IntoIterator, I::Item: AsRef<str> {


### PR DESCRIPTION
Fixes #312.
 - All results yielding `ParseError` in the doctests should now be handled with the ? operator.
 - Some other specific results are ~unwrapped with `expect()`~ mapped to a placeholder string message, such as in URLs that are not _cannot-be-a-base_. Users are then expected to adjust this mapping depending on their use case. Once #299 is resolved, we'll be able to propagate these normally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/323)
<!-- Reviewable:end -->
