### PR TITLE
Fix #305 Implement Debug for many types

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -13,6 +13,7 @@
 #[cfg(feature = "query_encoding")] extern crate encoding;
 
 use std::borrow::Cow;
+#[cfg(feature = "query_encoding")] use std::fmt::{self, Write, Debug, Formatter};
 
 #[cfg(feature = "query_encoding")] use self::encoding::types::{DecoderTrap, EncoderTrap};
 #[cfg(feature = "query_encoding")] use self::encoding::label::encoding_from_whatwg_label;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -95,7 +95,7 @@ impl Debug for EncodingOverride {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "EncodingOverride {{ encoding: ")?;
         match self.encoding {
-            Some(_) => write!(f, "Some(EncodingOverride) }}"),
+            Some(e) => write!(f, "{} }}", e.name()),
             None => write!(f, "None }}")
         }
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 #[cfg(feature = "query_encoding")] pub use self::encoding::types::EncodingRef;
 
 #[cfg(feature = "query_encoding")]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct EncodingOverride {
     /// `None` means UTF-8.
     encoding: Option<EncodingRef>
@@ -91,7 +91,7 @@ impl EncodingOverride {
 
 
 #[cfg(not(feature = "query_encoding"))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct EncodingOverride;
 
 #[cfg(not(feature = "query_encoding"))]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 #[cfg(feature = "query_encoding")] pub use self::encoding::types::EncodingRef;
 
 #[cfg(feature = "query_encoding")]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct EncodingOverride {
     /// `None` means UTF-8.
     encoding: Option<EncodingRef>
@@ -89,6 +89,16 @@ impl EncodingOverride {
     }
 }
 
+#[cfg(feature = "query_encoding")]
+impl Debug for EncodingOverride {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "EncodingOverride {{ encoding: ")?;
+        match self.encoding {
+            Some(_) => write!(f, "Some(EncodingOverride) }}"),
+            None => write!(f, "None }}")
+        }
+    }
+}
 
 #[cfg(not(feature = "query_encoding"))]
 #[derive(Copy, Clone, Debug)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -13,7 +13,7 @@
 #[cfg(feature = "query_encoding")] extern crate encoding;
 
 use std::borrow::Cow;
-#[cfg(feature = "query_encoding")] use std::fmt::{self, Write, Debug, Formatter};
+#[cfg(feature = "query_encoding")] use std::fmt::{self, Debug, Formatter};
 
 #[cfg(feature = "query_encoding")] use self::encoding::types::{DecoderTrap, EncoderTrap};
 #[cfg(feature = "query_encoding")] use self::encoding::label::encoding_from_whatwg_label;

--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -81,7 +81,7 @@ pub fn parse_with_encoding<'a>(input: &'a [u8],
 }
 
 /// The return type of `parse()`.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Parse<'a> {
     input: &'a [u8],
     encoding: EncodingOverride,
@@ -145,6 +145,7 @@ impl<'a> Parse<'a> {
 }
 
 /// Like `Parse`, but yields pairs of `String` instead of pairs of `Cow<str>`.
+#[derive(Debug)]
 pub struct ParseIntoOwned<'a> {
     inner: Parse<'a>
 }
@@ -168,6 +169,7 @@ pub fn byte_serialize(input: &[u8]) -> ByteSerialize {
 }
 
 /// Return value of `byte_serialize()`.
+#[derive(Debug)]
 pub struct ByteSerialize<'a> {
     bytes: &'a [u8],
 }
@@ -209,6 +211,7 @@ impl<'a> Iterator for ByteSerialize<'a> {
 
 /// The [`application/x-www-form-urlencoded` serializer](
 /// https://url.spec.whatwg.org/#concept-urlencoded-serializer).
+#[derive(Debug)]
 pub struct Serializer<T: Target> {
     target: Option<T>,
     start_position: usize,

--- a/src/host.rs
+++ b/src/host.rs
@@ -176,7 +176,7 @@ impl<S: AsRef<str>> fmt::Display for Host<S> {
 
 /// This mostly exists because coherence rules don’t allow us to implement
 /// `ToSocketAddrs for (Host<S>, u16)`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HostAndPort<S=String> {
     pub host: Host<S>,
     pub port: u16,
@@ -213,10 +213,12 @@ impl<S: AsRef<str>> ToSocketAddrs for HostAndPort<S> {
 }
 
 /// Socket addresses for an URL.
+#[derive(Debug)]
 pub struct SocketAddrs {
     state: SocketAddrsState
 }
 
+#[derive(Debug)]
 enum SocketAddrsState {
     Domain(vec::IntoIter<SocketAddr>),
     One(SocketAddr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ use percent_encoding::{PATH_SEGMENT_ENCODE_SET, USERINFO_ENCODE_SET,
 use std::borrow::Borrow;
 use std::cmp;
 #[cfg(feature = "serde")] use std::error::Error;
-use std::fmt::{self, Write};
+use std::fmt::{self, Write, Debug, Formatter};
 use std::hash;
 use std::io;
 use std::mem;
@@ -210,6 +210,16 @@ impl<'a> ParseOptions<'a> {
             log_syntax_violation: self.log_syntax_violation,
             context: Context::UrlParser,
         }.parse_url(input)
+    }
+}
+
+impl<'a> Debug for ParseOptions<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "ParseOptions {{ base_url: {:?}, encoding_override: {:?}, log_syntax_violation: ", self.base_url, self.encoding_override)?;
+        match self.log_syntax_violation {
+            Some(_) => write!(f, "Some(Fn(&'static str)) }}"),
+            None => write!(f, "None }}")
+        }
     }
 }
 
@@ -1870,6 +1880,7 @@ fn io_error<T>(reason: &str) -> io::Result<T> {
 }
 
 /// Implementation detail of `Url::query_pairs_mut`. Typically not used directly.
+#[derive(Debug)]
 pub struct UrlQuery<'a> {
     url: &'a mut Url,
     fragment: Option<String>,

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -26,6 +26,7 @@ use Url;
 /// url.path_segments_mut().unwrap().pop().push("img").push("2/100%.png");
 /// assert_eq!(url.as_str(), "http://example.net/foo/img/2%2F100%25.png");
 /// ```
+#[derive(Debug)]
 pub struct PathSegmentsMut<'a> {
     url: &'a mut Url,
     after_first_slash: usize,

--- a/src/percent_encoding.rs
+++ b/src/percent_encoding.rs
@@ -77,7 +77,7 @@ macro_rules! define_encode_set {
 }
 
 /// This encode set is used for the path of cannot-be-a-base URLs.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub struct SIMPLE_ENCODE_SET;
 
@@ -163,7 +163,7 @@ pub fn utf8_percent_encode<E: EncodeSet>(input: &str, encode_set: E) -> PercentE
 }
 
 /// The return type of `percent_encode()` and `utf8_percent_encode()`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PercentEncode<'a, E: EncodeSet> {
     bytes: &'a [u8],
     encode_set: E,
@@ -249,7 +249,7 @@ pub fn percent_decode<'a>(input: &'a [u8]) -> PercentDecode<'a> {
 }
 
 /// The return type of `percent_decode()`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PercentDecode<'a> {
     bytes: slice::Iter<'a, u8>,
 }

--- a/src/percent_encoding.rs
+++ b/src/percent_encoding.rs
@@ -58,7 +58,7 @@ pub trait EncodeSet: Clone {
 macro_rules! define_encode_set {
     ($(#[$attr: meta])* pub $name: ident = [$base_set: expr] | {$($ch: pat),*}) => {
         $(#[$attr])*
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, Debug)]
         #[allow(non_camel_case_types)]
         pub struct $name;
 


### PR DESCRIPTION
For most types it was a simple matter of adding #[derive(Debug)] but
ParseOptions needed a manual implementation because the type of
log_syntax_violation is Option<&'a Fn(&'static str)> and Fn doesn't
implement Debug. log_syntax_violation is formatted as Some(Fn(&'static
str)) or None depending upon its value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/335)
<!-- Reviewable:end -->
