### PR TITLE
[idna] Preserve leading dots in host

### DIFF
--- a/idna/tests/uts46.rs
+++ b/idna/tests/uts46.rs
@@ -84,6 +84,16 @@ pub fn collect_tests<F: FnMut(String, TestFn)>(add_test: &mut F) {
                 return;
             }
 
+            if let Err(ref errors) = result {
+                if errors.eq(&vec![uts46::Error::TooShortForDns]) {
+                    // Conformant implementations may produce error where test file has strings.
+                    // Test file drop all leading dots (leading empty labels), in contrast to spec.
+                    // So, we allo TooShortForDns failers on test cases.
+                    // https://github.com/servo/rust-url/issues/166
+                    return;
+                }
+            }
+
             assert!(result.is_ok(), "Couldn't parse {} | original: {} | error: {:?}",
                     source, original, result.err());
             let output = result.ok().unwrap();

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -344,6 +344,13 @@ fn test_set_host() {
     assert_eq!(url.as_str(), "foobar:/hello");
 }
 
+#[test]
+// https://github.com/servo/rust-url/issues/166
+fn test_leading_dots() {
+    assert_eq!(Host::parse(".org").unwrap(), Host::Domain(".org".to_owned()));
+    assert_eq!(Url::parse("file://./foo").unwrap().domain(), Some("."));
+}
+
 // This is testing that the macro produces buildable code when invoked
 // inside both a module and a function
 #[test]


### PR DESCRIPTION
A retry of https://github.com/servo/rust-url/pull/171

This diff changes the behavior of ToASCII step to match the spec and
prevent failures on some cases when a domain name starts with leading
dots (FULL STOPs), as requested in
https://github.com/servo/rust-url/issues/166.

The change in the code results in a few failures for test cases of the
Conformance Testing data provided with UTS #46. But, as the header of
the test data file (IdnaTest.txt) says: "If the file does not indicate
an error, then the implementation must either have an error, or must
have a matching result."

Therefore, failing on those test cases does not break conformance with
UTS #46, and to some level, anticipated.

As mentioned in https://github.com/servo/rust-url/issues/166, a feedback
is submitted for this inconsistency and the test logic can be improved
later if the data file addresses the comments.

Until then, we can throw less errors and maintain passing conformance
tests with this diff.

To keep the side-effects of ignoring errors during test runs as minimum
as possible, I have separated `TooShortForDns` error from
`TooLongForDns`. The `Error` struct has been kept private, so the change
won't affect any library users.

Fix #166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/337)
<!-- Reviewable:end -->
