### PR TITLE
[idna] Upgrade unicode-bidi to 0.3.0

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -19,6 +19,6 @@ rustc-test = "0.1"
 rustc-serialize = "0.3"
 
 [dependencies]
-unicode-bidi = "0.2.4"
+unicode-bidi = "0.3"
 unicode-normalization = "0.1.3"
 matches = "0.1"


### PR DESCRIPTION
For the needs of `idna`, `unicode-bidi:0.3.0` is backwards compatible,
but this upgrade is needed to that `servo` can upgrade to the new
version.

Servo upgrade: https://github.com/servo/servo/pull/16779

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/343)
<!-- Reviewable:end -->
