### PR TITLE
move percent_encoding to its own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "servo/rust-url" }
 appveyor = { repository = "servo/rust-url" }
 
 [workspace]
-members = [".", "idna", "url_serde"]
+members = [".", "idna", "percent_encoding", "url_serde"]
 
 [[test]]
 name = "unit"
@@ -44,5 +44,6 @@ encoding = {version = "0.2", optional = true}
 heapsize = {version = ">=0.1.1, <0.4", optional = true}
 idna = { version = "0.1.0", path = "./idna" }
 matches = "0.1"
+percent_encoding = { version = "1.0.0", path = "./percent_encoding" }
 rustc-serialize = {version = "0.3", optional = true}
 serde = {version = ">=0.6.1, <0.9", optional = true}

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "percent_encoding"
+version = "1.0.0"
+authors = ["The rust-url developers"]
+description = "Percent encoding and decoding"
+repository = "https://github.com/servo/rust-url/"
+license = "MIT/Apache-2.0"
+
+[lib]
+doctest = false
+test = false
+
+[[test]]
+name = "tests"
+harness = false
+
+[dev-dependencies]
+rustc-test = "0.1"
+rustc-serialize = "0.3"
+
+[dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css")
 #[cfg(feature="heapsize")] #[macro_use] extern crate heapsize;
 
 pub extern crate idna;
+pub extern crate percent_encoding;
 
 use encoding::EncodingOverride;
 #[cfg(feature = "heapsize")] use heapsize::HeapSizeOf;
@@ -131,7 +132,6 @@ mod parser;
 mod slicing;
 
 pub mod form_urlencoded;
-pub mod percent_encoding;
 pub mod quirks;
 
 /// A parsed URL record.
@@ -1879,5 +1879,50 @@ pub struct UrlQuery<'a> {
 impl<'a> Drop for UrlQuery<'a> {
     fn drop(&mut self) {
         self.url.restore_already_parsed_fragment(self.fragment.take())
+    }
+}
+
+
+/// Define a new struct
+/// that implements the [`EncodeSet`](percent_encoding/trait.EncodeSet.html) trait,
+/// for use in [`percent_decode()`](percent_encoding/fn.percent_encode.html)
+/// and related functions.
+///
+/// Parameters are characters to include in the set in addition to those of the base set.
+/// See [encode sets specification](http://url.spec.whatwg.org/#simple-encode-set).
+///
+/// Example
+/// =======
+///
+/// ```rust
+/// #[macro_use] extern crate url;
+/// use url::percent_encoding::{utf8_percent_encode, SIMPLE_ENCODE_SET};
+/// define_encode_set! {
+///     /// This encode set is used in the URL parser for query strings.
+///     pub QUERY_ENCODE_SET = [SIMPLE_ENCODE_SET] | {' ', '"', '#', '<', '>'}
+/// }
+/// # fn main() {
+/// assert_eq!(utf8_percent_encode("foo bar", QUERY_ENCODE_SET).collect::<String>(), "foo%20bar");
+/// # }
+/// ```
+#[macro_export]
+macro_rules! define_encode_set {
+    ($(#[$attr: meta])* pub $name: ident = [$base_set: expr] | {$($ch: pat),*}) => {
+        $(#[$attr])*
+        #[derive(Copy, Clone)]
+        #[allow(non_camel_case_types)]
+        pub struct $name;
+
+        impl $crate::percent_encoding::EncodeSet for $name {
+            #[inline]
+            fn contains(&self, byte: u8) -> bool {
+                match byte as char {
+                    $(
+                        $ch => true,
+                    )*
+                    _ => $base_set.contains(byte)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- I arbitrarily chose `percent_encode`, but I could update it to be `percent_encoding` if preferred.
- The macro `define_encode_set` duplicated, to maintain backwards compatibility for `url`.
- I set it 1.0.0 since this is a public dependency of `url`, and so it can't make API breaking changes easily without affecting `url`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/347)
<!-- Reviewable:end -->
