### PR TITLE
Allow heapsize 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "url"
 # When updating version, also modify html_root_url in the lib.rs
-version = "1.4.0"
+version = "1.4.1"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"
@@ -41,7 +41,7 @@ heap_size = ["heapsize"]
 
 [dependencies]
 encoding = {version = "0.2", optional = true}
-heapsize = {version = ">=0.1.1, <0.4", optional = true}
+heapsize = {version = ">=0.1.1, <0.5", optional = true}
 idna = { version = "0.1.0", path = "./idna" }
 matches = "0.1"
 rustc-serialize = {version = "0.3", optional = true}


### PR DESCRIPTION
This is needed to bump euclid in servo which is needed for serde 1.0 support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/350)
<!-- Reviewable:end -->
