### PR TITLE
percent-encoding doesn't require any dev-dependencies

### DIFF
--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -10,7 +10,3 @@ license = "MIT/Apache-2.0"
 doctest = false
 test = false
 path = "lib.rs"
-
-[dev-dependencies]
-rustc-test = "0.1"
-rustc-serialize = "0.3"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/377)
<!-- Reviewable:end -->
