### PR TITLE
Add error documentation on parse function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,13 @@ impl Url {
     /// # }
     /// # run().unwrap();
     /// ```
+    /// 
+    /// # Errors
+    ///
+    /// If the function can not parse an absolute URL from the given string,
+    /// a [`ParseError`] variant will be returned.
+    ///
+    /// [`ParseError`]: enum.ParseError.html
     #[inline]
     pub fn parse(input: &str) -> Result<Url, ::ParseError> {
         Url::options().parse(input)


### PR DESCRIPTION
See: https://github.com/servo/rust-url/issues/314

This is just a try, feel free to close or comment if it's not good. I just submit one error documentation because I want to clearly understand what's the pattern before submitting more documentation: I still have to learn, so I prefer just trying on one function for now (but I can help after that)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/379)
<!-- Reviewable:end -->
