### PR TITLE
Bump heapsize to at least 0.4.1 (relicensed)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ heap_size = ["heapsize"]
 
 [dependencies]
 encoding = {version = "0.2", optional = true}
-heapsize = {version = ">=0.1.1, <0.5", optional = true}
+heapsize = {version = ">=0.4.1, <0.5", optional = true}
 idna = { version = "0.1.0", path = "./idna" }
 matches = "0.1"
 percent-encoding = { version = "1.0.0", path = "./percent_encoding" }


### PR DESCRIPTION
Heapsize was released as `0.4.1` to reflect the license change. (https://github.com/servo/heapsize/pull/85).

Fixes https://github.com/servo/rust-url/issues/317.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/381)
<!-- Reviewable:end -->
