### PR TITLE
Fix repository URL for AppVeyor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 
 [badges]
 travis-ci = { repository = "servo/rust-url" }
-appveyor = { repository = "servo/rust-url" }
+appveyor = { repository = "Manishearth/rust-url" }
 
 [workspace]
 members = [".", "idna", "percent_encoding", "url_serde"]


### PR DESCRIPTION
For some reason, this project is not registered under `servo/rust-url` on AppVeyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/384)
<!-- Reviewable:end -->
