### PR TITLE
Upgrade idna dependency to 0.1.4 and publish rust-url 1.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "url"
 # When updating version, also modify html_root_url in the lib.rs
-version = "1.5.1"
+version = "1.5.2"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"
@@ -42,7 +42,7 @@ heap_size = ["heapsize"]
 [dependencies]
 encoding = {version = "0.2", optional = true}
 heapsize = {version = ">=0.4.1, <0.5", optional = true}
-idna = { version = "0.1.0", path = "./idna" }
+idna = { version = "0.1.4", path = "./idna" }
 matches = "0.1"
 percent-encoding = { version = "1.0.0", path = "./percent_encoding" }
 rustc-serialize = {version = "0.3", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css");
 # run().unwrap();
 */
 
-#![doc(html_root_url = "https://docs.rs/url/1.5.1")]
+#![doc(html_root_url = "https://docs.rs/url/1.5.2")]
 
 #[cfg(feature="rustc-serialize")] extern crate rustc_serialize;
 #[macro_use] extern crate matches;


### PR DESCRIPTION
We would like to update the dependency in Gecko to get the latest idna table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/385)
<!-- Reviewable:end -->
