### PR TITLE
Add missing whitespace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1757,6 +1757,7 @@ impl Url {
     /// ```
     ///
     /// Setup username to user1
+    ///
     /// ```rust
     /// use url::{Url, ParseError};
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1762,11 +1762,11 @@ impl Url {
     /// use url::{Url, ParseError};
     ///
     /// # fn run() -> Result<(), ParseError> {
-    /// let mut url = Url::parse("ftp://:secre1@example.com")?;
+    /// let mut url = Url::parse("ftp://:secre1@example.com/")?;
     /// let result = url.set_username("user1");
     /// assert!(result.is_ok());
     /// assert_eq!(url.username(), "user1");
-    /// assert_eq!(url.as_str(), "ftp://user1:secre1@example.com");
+    /// assert_eq!(url.as_str(), "ftp://user1:secre1@example.com/");
     /// # Ok(())
     /// # }
     /// # run().unwrap();


### PR DESCRIPTION
Without this whitespace, the example code would be rendered as paragraph text. This change fixes it so the example code is rendered as code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/389)
<!-- Reviewable:end -->
