### PR TITLE
Fix typo in parse.rs s/authentification/authentication/

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -683,7 +683,7 @@ impl<'a> Parser<'a> {
                         self.syntax_violation("unencoded @ sign in username or password")
                     } else {
                         self.syntax_violation(
-                            "embedding authentification information (username or password) \
+                            "embedding authentication information (username or password) \
                             in an URL is not recommended")
                     }
                     last_at = Some((char_count, remaining.clone()))


### PR DESCRIPTION
This is related to [cargo PR#4532](https://github.com/rust-lang/cargo/pull/4532). This is a small patch we applied in Debian to fix the typo in cargo output messages. Just forwarding the patches to upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/390)
<!-- Reviewable:end -->
