### PR TITLE
Make links in docs work with commonmark

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -137,7 +137,7 @@ impl<'a> Host<&'a str> {
 impl Host<String> {
     /// Parse a host: either an IPv6 address in [] square brackets, or a domain.
     ///
-    /// https://url.spec.whatwg.org/#host-parsing
+    /// <https://url.spec.whatwg.org/#host-parsing>
     pub fn parse(input: &str) -> Result<Self, ParseError> {
         if input.starts_with('[') {
             if !input.ends_with(']') {
@@ -309,7 +309,7 @@ fn longest_zero_sequence(pieces: &[u16; 8]) -> (isize, isize) {
     }
 }
 
-/// https://url.spec.whatwg.org/#ipv4-number-parser
+/// <https://url.spec.whatwg.org/#ipv4-number-parser>
 fn parse_ipv4number(mut input: &str) -> Result<u32, ()> {
     let mut r = 10;
     if input.starts_with("0x") || input.starts_with("0X") {
@@ -331,7 +331,7 @@ fn parse_ipv4number(mut input: &str) -> Result<u32, ()> {
     }
 }
 
-/// https://url.spec.whatwg.org/#concept-ipv4-parser
+/// <https://url.spec.whatwg.org/#concept-ipv4-parser>
 fn parse_ipv4addr(input: &str) -> ParseResult<Option<Ipv4Addr>> {
     if input.is_empty() {
         return Ok(None)
@@ -368,7 +368,7 @@ fn parse_ipv4addr(input: &str) -> ParseResult<Option<Ipv4Addr>> {
     Ok(Some(Ipv4Addr::from(ipv4)))
 }
 
-/// https://url.spec.whatwg.org/#concept-ipv6-parser
+/// <https://url.spec.whatwg.org/#concept-ipv6-parser>
 fn parse_ipv6addr(input: &str) -> ParseResult<Ipv6Addr> {
     let input = input.as_bytes();
     let len = input.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ impl Url {
         Ok(())
     }
 
-    /// Return the origin of this URL (https://url.spec.whatwg.org/#origin)
+    /// Return the origin of this URL (<https://url.spec.whatwg.org/#origin>)
     ///
     /// Note: this returns an opaque origin for `file:` URLs, which causes
     /// `url.origin() != url.origin()`.

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -49,7 +49,7 @@ pub fn url_origin(url: &Url) -> Origin {
 /// - If the scheme is anything else, the origin is opaque, meaning
 ///   the URL does not have the same origin as any other URL.
 ///
-/// For more information see https://url.spec.whatwg.org/#origin
+/// For more information see <https://url.spec.whatwg.org/#origin>
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Origin {
     /// A globally unique identifier
@@ -86,7 +86,7 @@ impl Origin {
         matches!(*self, Origin::Tuple(..))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin
+    /// <https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin>
     pub fn ascii_serialization(&self) -> String {
         match *self {
             Origin::Opaque(_) => "null".to_owned(),
@@ -100,7 +100,7 @@ impl Origin {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin
+    /// <https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin>
     pub fn unicode_serialization(&self) -> String {
         match *self {
             Origin::Opaque(_) => "null".to_owned(),


### PR DESCRIPTION
Fixes formatting with the new pulldown-cmark Markdown parser (rust-lang/rust#44229).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/400)
<!-- Reviewable:end -->
