### PR TITLE
Switch to non-transitional IDNA

### DIFF
--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -49,7 +49,7 @@ pub mod uts46;
 pub fn domain_to_ascii(domain: &str) -> Result<String, uts46::Errors> {
     uts46::to_ascii(domain, uts46::Flags {
         use_std3_ascii_rules: false,
-        transitional_processing: true, // XXX: switch when Firefox does
+        transitional_processing: false,
         verify_dns_length: false,
     })
 }
@@ -67,7 +67,7 @@ pub fn domain_to_unicode(domain: &str) -> (String, Result<(), uts46::Errors>) {
         use_std3_ascii_rules: false,
 
         // Unused:
-        transitional_processing: true,
+        transitional_processing: false,
         verify_dns_length: false,
     })
 }

--- a/tests/urltestdata.json
+++ b/tests/urltestdata.json
@@ -3684,6 +3684,21 @@
     "hash": ""
   },
   {
+    "input": "https://faß.ExAmPlE/",
+    "base": "about:blank",
+    "href": "https://xn--fa-hia.example/",
+    "origin": "https://xn--fa-hia.example",
+    "protocol": "https:",
+    "username": "",
+    "password": "",
+    "host": "xn--fa-hia.example",
+    "hostname": "xn--fa-hia.example",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
     "input": "sc://faß.ExAmPlE/",
     "base": "about:blank",
     "href": "sc://fa%C3%9F.ExAmPlE/",


### PR DESCRIPTION
Firefox has switch over a year ago, and the URL spec as well.