### PR TITLE
Remove path related methods in wasm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: rust
-rust:
-  - nightly
-  - beta
-  - stable
-  - 1.17.0
 script: make test
+
+jobs:
+  include:
+  - rust: nightly
+  - rust: beta
+  - rust: stable
+  - rust: 1.17.0
+  - rust: nightly
+    env:
+    - WASM32=true  # just to show it in travis UI
+    install:
+    - rustup target add wasm32-unknown-unknown
+    script:
+    - cargo build --target=wasm32-unknown-unknown
+
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1935,6 +1935,7 @@ impl Url {
     /// # run().unwrap();
     /// # }
     /// ```
+    #[cfg(any(unix, windows, target_os="redox"))]
     pub fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {
         let mut serialization = "file://".to_owned();
         let host_start = serialization.len() as u32;
@@ -1970,6 +1971,7 @@ impl Url {
     ///
     /// Note that `std::path` does not consider trailing slashes significant
     /// and usually does not include them (e.g. in `Path::parent()`).
+    #[cfg(any(unix, windows, target_os="redox"))]
     pub fn from_directory_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {
         let mut url = Url::from_file_path(path)?;
         if !url.serialization.ends_with('/') {
@@ -2051,6 +2053,7 @@ impl Url {
     /// (That is, if the percent-decoded path contains a NUL byte or,
     /// for a Windows path, is not UTF-8.)
     #[inline]
+    #[cfg(any(unix, windows, target_os="redox"))]
     pub fn to_file_path(&self) -> Result<PathBuf, ()> {
         if let Some(segments) = self.path_segments() {
             let host = match self.host() {
@@ -2296,6 +2299,7 @@ fn path_to_file_url_segments_windows(path: &Path, serialization: &mut String)
     }
     Ok((host_end, host_internal))
 }
+
 
 #[cfg(any(unix, target_os = "redox"))]
 fn file_url_segments_to_pathbuf(host: Option<&str>, segments: str::Split<char>) -> Result<PathBuf, ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl Url {
     /// # }
     /// # run().unwrap();
     /// ```
-    /// 
+    ///
     /// # Errors
     ///
     /// If the function can not parse an absolute URL from the given string,
@@ -315,7 +315,7 @@ impl Url {
     /// ```rust
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let base = Url::parse("https://example.net/a/b.html")?;
     /// let url = base.join("c.png")?;
@@ -331,7 +331,7 @@ impl Url {
     ///
     /// # Errors
     ///
-    /// If the function can not parse an URL from the given string 
+    /// If the function can not parse an URL from the given string
     /// with this URL as the base URL, a [`ParseError`] variant will be returned.
     ///
     /// [`ParseError`]: enum.ParseError.html
@@ -1177,11 +1177,11 @@ impl Url {
     /// assert_eq!(url.as_str(), "https://example.com/data.csv");
 
     /// url.set_fragment(Some("cell=4,1-6,2"));
-    /// assert_eq!(url.as_str(), "https://example.com/data.csv#cell=4,1-6,2");  
+    /// assert_eq!(url.as_str(), "https://example.com/data.csv#cell=4,1-6,2");
     /// assert_eq!(url.fragment(), Some("cell=4,1-6,2"));
     ///
     /// url.set_fragment(None);
-    /// assert_eq!(url.as_str(), "https://example.com/data.csv");    
+    /// assert_eq!(url.as_str(), "https://example.com/data.csv");
     /// assert!(url.fragment().is_none());
     /// # Ok(())
     /// # }
@@ -1234,7 +1234,7 @@ impl Url {
     /// assert_eq!(url.as_str(), "https://example.com/products");
     ///
     /// url.set_query(Some("page=2"));
-    /// assert_eq!(url.as_str(), "https://example.com/products?page=2");    
+    /// assert_eq!(url.as_str(), "https://example.com/products?page=2");
     /// assert_eq!(url.query(), Some("page=2"));
     /// # Ok(())
     /// # }
@@ -1330,12 +1330,12 @@ impl Url {
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("https://example.com")?;
     /// url.set_path("api/comments");
-    /// assert_eq!(url.as_str(), "https://example.com/api/comments");    
+    /// assert_eq!(url.as_str(), "https://example.com/api/comments");
     /// assert_eq!(url.path(), "/api/comments");
     ///
     /// let mut url = Url::parse("https://example.com/api")?;
     /// url.set_path("data/report.csv");
-    /// assert_eq!(url.as_str(), "https://example.com/data/report.csv");    
+    /// assert_eq!(url.as_str(), "https://example.com/data/report.csv");
     /// assert_eq!(url.path(), "/data/report.csv");
     /// # Ok(())
     /// # }
@@ -1496,7 +1496,7 @@ impl Url {
     /// ```
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("foo://example.net")?;
     /// let result = url.set_host(None);
@@ -1512,7 +1512,7 @@ impl Url {
     /// ```
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_host(None);
@@ -1528,7 +1528,7 @@ impl Url {
     /// ```
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("mailto:rms@example.net")?;
     ///
@@ -1838,7 +1838,7 @@ impl Url {
     /// ```
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_scheme("foo");
@@ -1855,7 +1855,7 @@ impl Url {
     /// ```
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("https://example.net")?;
     /// let result = url.set_scheme("foõ");
@@ -1871,7 +1871,7 @@ impl Url {
     /// ```
     /// use url::Url;
     /// # use url::ParseError;
-    /// 
+    ///
     /// # fn run() -> Result<(), ParseError> {
     /// let mut url = Url::parse("mailto:rms@example.net")?;
     /// let result = url.set_scheme("https");
@@ -1920,7 +1920,7 @@ impl Url {
     /// ```
     /// # if cfg!(unix) {
     /// use url::Url;
-    /// 
+    ///
     /// # fn run() -> Result<(), ()> {
     /// let url = Url::from_file_path("/tmp/foo.txt")?;
     /// assert_eq!(url.as_str(), "file:///tmp/foo.txt");


### PR DESCRIPTION
Temporarily fixes #418 and #417

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/419)
<!-- Reviewable:end -->
