### PR TITLE
Enable rustdoc for feature query_encoding on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ matches = "0.1"
 percent-encoding = { version = "1.0.0", path = "./percent_encoding" }
 rustc-serialize = {version = "0.3", optional = true}
 serde = {version = ">=0.6.1, <0.9", optional = true}
+
+[package.metadata.docs.rs]
+features = ["query_encoding"]


### PR DESCRIPTION
So that ParseOptions::encoding_override shows up on docs.rs  This relates to and was requested by me in #308.  I believe this is how to implement.

See onur/docs.rs@62fdcf605 for the docs.rs support of this config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/427)
<!-- Reviewable:end -->
