### PR TITLE
Define `HEADER_FIELD_ENCODE_SET`

### DIFF
--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -156,6 +156,16 @@ define_encode_set! {
     }
 }
 
+define_encode_set! {
+    /// RFC8187 HTTP header field encoding
+    ///
+    /// Encodes all bytes that are not RFC7230 token bytes, in addition to asterisk (*), single quote ('),
+    /// and percent (%). Commonly used for encoding Unicode filenames in a `Content-Disposition` header.
+    pub HEADER_FIELD_ENCODE_SET = [SIMPLE_ENCODE_SET] | {
+        '*', '\'', '%', '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t'
+    }
+}
+
 /// Return the percent-encoding of the given bytes.
 ///
 /// This is unconditional, unlike `percent_encode()` which uses an encode set.


### PR DESCRIPTION
This is needed for encoding UTF-8 in header fields, e.g. `Content-Disposition: attachment; filename*=UTF-8''...`. Defined in [RFC8187](https://tools.ietf.org/html/rfc8187). I'd appreciate a double-check that I got the characters right.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/428)
<!-- Reviewable:end -->
