### PR TITLE
Improve syntax violations interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,12 +259,12 @@ impl<'a> ParseOptions<'a> {
     }
 
     /// Parse an URL string with the configuration so far.
-    pub fn parse(self, input: &str) -> Result<Url, ::ParseError> {
+    pub fn parse(&self, input: &str) -> Result<Url, ::ParseError> {
         Parser {
             serialization: String::with_capacity(input.len()),
             base_url: self.base_url,
             query_encoding_override: self.encoding_override,
-            syntax_violation_callback: self.syntax_violation_callback,
+            syntax_violation_callback: self.syntax_violation_callback.clone(),
             context: Context::UrlParser,
         }.parse_url(input)
     }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -13,7 +13,7 @@ extern crate url;
 
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 use url::{Host, HostAndPort, Url, form_urlencoded};
@@ -528,4 +528,22 @@ fn test_syntax_violation_callback_lifetimes() {
         unwrap();
     assert_eq!(url.path(), "/path");
     assert_eq!(violation.take(), Some(Backslash));
+}
+
+#[test]
+fn test_options_reuse() {
+    use url::SyntaxViolation::*;
+    let violations = RefCell::new(Vec::new());
+
+    let options = Url::options().
+        syntax_violation_callback(Some(|v| {
+            violations.borrow_mut().push(v);
+        }));
+    let url = options.parse("http:////mozilla.org").unwrap();
+
+    let options = options.base_url(Some(&url));
+    let url = options.parse("/sub\\path").unwrap();
+    assert_eq!(url.as_str(), "http://mozilla.org/sub/path");
+    assert_eq!(*violations.borrow(),
+               vec!(ExpectedDoubleSlash, Backslash));
 }


### PR DESCRIPTION
This makes programmatic use of syntax violations more practical while further centralizing this concern in the parser, which should be a maintenance win.  An `Rc<Fn>` is introduced internally to satisfy borrow rules while improving ergonomics.  The presumed minimal additional cost of this is only incurred if the syntax violation feature is used.  Since existing public interface is maintained and changes are internal, I believe this meets requirements for backward compatibility, and testing agrees, but reviewers should definitely cover that aspect. 

### Summary of changes

* New `SyntaxViolation` enum with descriptions the same as the prior violation static strings.  This enables programmatic use of these violations by variant, e.g. ignoring some, warning on others, etc. Enum implementation uses the same macro expansion pattern as was used for `ParseError`. 

* New `syntax_violation_callback` signature in `ParseOptions` and `Parser`.

* Deprecated `log_syntax_violation` and re-implemented as adapter to new callback, passing the same violation descriptions for backward compatibility.

* Unit tests for old `log_syntax_violation` compatibility, and new `syntax_violation_callback` including a tested doc example.

* Includes rustdoc for old and new interfaces including example usage of new callback, as requested in #308.

**Below items edited in light of discussion:**

* Improved ergonomics for `ParseOptions` and `syntax_violation_callback.`  `ParseOptions::parse` _now_ takes &self, so `ParseOptions` can _still_ be used repeatedly.  The new `syntax_violation_callback` is passed `Fn` by value and can be passed inline in user code. 

* Potential breaking changes: `ParseOptions` is no longer `Copy`, and `ParseOptions::parse` takes `&self` (was `self`, with `Copy`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/430)
<!-- Reviewable:end -->
