### PR TITLE
Exclude unneeded files from the crate package.

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["The rust-url developers"]
 description = "IDNA (Internationalizing Domain Names in Applications) and Punycode."
 repository = "https://github.com/servo/rust-url/"
 license = "MIT/Apache-2.0"
+exclude = [
+    "tests/IdnaTest.txt",
+    "src/IdnaMappingTable.txt",
+    "src/make_uts46_mapping_table.py"
+]
 
 [lib]
 doctest = false


### PR DESCRIPTION
This decreases `*.crate` file size from 282KiB to 90KiB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/435)
<!-- Reviewable:end -->
