### PR TITLE
Update to rustc_test 0.3, unbreak tests on nightly-2018-02-25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ harness = false
 test = false
 
 [dev-dependencies]
-rustc-test = "0.2"
+rustc-test = "0.3"
 rustc-serialize = "0.3"
 serde_json = ">=0.6.1, <0.9"
 

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -18,7 +18,7 @@ harness = false
 name = "unit"
 
 [dev-dependencies]
-rustc-test = "0.2"
+rustc-test = "0.3"
 rustc-serialize = "0.3"
 
 [dependencies]

--- a/idna/tests/tests.rs
+++ b/idna/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate idna;
 extern crate rustc_serialize;
-extern crate test;
+extern crate rustc_test as test;
 
 mod punycode;
 mod uts46;

--- a/idna/tests/uts46.rs
+++ b/idna/tests/uts46.rs
@@ -108,7 +108,7 @@ fn unescape(input: &str) -> String {
                             let c2 = chars.next().unwrap().to_digit(16).unwrap();
                             let c3 = chars.next().unwrap().to_digit(16).unwrap();
                             let c4 = chars.next().unwrap().to_digit(16).unwrap();
-                            match char::from_u32((((c1 * 16 + c2) * 16 + c3) * 16 + c4))
+                            match char::from_u32(((c1 * 16 + c2) * 16 + c3) * 16 + c4)
                             {
                                 Some(c) => output.push(c),
                                 None => { output.push_str(&format!("\\u{:X}{:X}{:X}{:X}",c1,c2,c3,c4)); }

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -9,7 +9,7 @@
 //! Data-driven tests
 
 extern crate rustc_serialize;
-extern crate test;
+extern crate rustc_test as test;
 extern crate url;
 
 use rustc_serialize::json::{self, Json};


### PR DESCRIPTION
Version 0.2 of the crates.io package `rustc_test` uses `test` as its rustc crate name, shadowing the `test` crate from the standard library. This made up subject to breaking changes to its private APIs:

https://travis-ci.org/SimonSapin/run-nightly/builds/345808272#L549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/439)
<!-- Reviewable:end -->
