### PR TITLE
fix(cargo): Update minimum matches crate version that compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ heap_size = ["heapsize"]
 encoding = {version = "0.2", optional = true}
 heapsize = {version = ">=0.4.1, <0.5", optional = true}
 idna = { version = "0.1.0", path = "./idna" }
-matches = "0.1"
+matches = "0.1.1"
 percent-encoding = { version = "1.0.0", path = "./percent_encoding" }
 rustc-serialize = {version = "0.3", optional = true}
 serde = {version = ">=0.6.1, <0.9", optional = true}


### PR DESCRIPTION
While working on a minimum cargo dependency installer I noticed that this crate does not compile with matches 0.1.0.

```
cargo update -Z minimal-versions
    ...
    Updating matches v0.1.6 -> v0.1.0
    ...
cargo build
   Compiling matches v0.1.0
error: macros that expand to items must either be surrounded with braces or followed by a semicolon
  --> /home/klausi/.cargo/registry/src/github.com-1ecc6299db9ec823/matches-0.1.0/lib.rs:4:21
   |
4  |   macro_rules! matches(
   |  _____________________^
5  | |     ($expression: expr, $($pattern:pat)|+) => (
6  | |         matches!($expression, $($pattern)|+ if true)
7  | |     );
...  |
13 | |     );
14 | | )
   | |_^

error: aborting due to previous error

error: Could not compile `matches`.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/441)
<!-- Reviewable:end -->
