### PR TITLE
Fix `to_file_path` for relative paths with drive letters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2411,8 +2411,9 @@ fn file_url_segments_to_pathbuf_windows(host: Option<&str>, mut segments: str::S
         }
     }
     let path = PathBuf::from(string);
-    debug_assert!(path.is_absolute(),
-                  "to_file_path() failed to produce an absolute Path");
+    if !path.is_absolute() {
+        return Err(());
+    }
     Ok(path)
 }
 

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -86,6 +86,29 @@ fn new_path_windows_fun() {
     }
 }
 
+#[test]
+fn to_file_path_for_relative_windows_paths() {
+    if cfg!(windows) {
+        let url = Url::parse("file://example.com/C:foo").unwrap();
+        assert!(url.to_file_path().is_ok());
+
+        let url = Url::parse("file://example.com/C:").unwrap();
+        assert!(url.to_file_path().is_err());
+
+        let url = Url::parse("file:///E:foo").unwrap();
+        assert!(url.to_file_path().is_err());
+
+        let url = Url::parse("file:///E:").unwrap();
+        assert!(url.to_file_path().is_err());
+
+        let url = Url::parse("file://localhost/C:foo").unwrap();
+        assert!(url.to_file_path().is_err());
+
+        let url = Url::parse("file://localhost/C:").unwrap();
+        assert!(url.to_file_path().is_err());
+    }
+}
+
 
 #[test]
 fn new_directory_paths() {


### PR DESCRIPTION
Hi!

I've recently hit [this debug assertion](https://github.com/servo/rust-url/blob/04d5ec1e7f3e70c850ff2e7ba7d83d446926defe/src/lib.rs#L2414) on windows for paths like `file://C:`.

I've added a couple of tests and a "fix", which just turns the assertion into error. I have no idea how to fix this properly.