### PR TITLE
Add ParseOptions::encoding_override_lookup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,24 @@ impl<'a> ParseOptions<'a> {
         self
     }
 
+    /// Override the character encoding of query strings.
+    /// This is a legacy concept only relevant for HTML.
+    ///
+    /// `label` is the WHATWG [encoding label](https://encoding.spec.whatwg.org/#names-and-labels).
+    ///
+    /// Silently fails if `label` is invalid.
+    ///
+    /// This method is only available if the `query_encoding`
+    /// [feature](http://doc.crates.io/manifest.html#the-features-section]) is enabled.
+    #[cfg(feature = "query_encoding")]
+    pub fn encoding_override_lookup(mut self, label: &[u8]) -> Self {
+        self.encoding_override = match EncodingOverride::lookup(label) {
+            Some(encoding_override) => encoding_override.to_output_encoding(),
+            None => self.encoding_override,
+        };
+        self
+    }
+
     /// Call the provided function or closure on non-fatal parse errors, passing
     /// a static string description.  This method is deprecated in favor of
     /// `syntax_violation_callback` and is implemented as an adaptor for the

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -543,3 +543,22 @@ fn test_options_reuse() {
     assert_eq!(*violations.borrow(),
                vec!(ExpectedDoubleSlash, Backslash));
 }
+
+#[cfg(feature = "query_encoding")]
+#[test]
+fn test_encoding_override_lookup() {
+    let url = Url::options()
+        .encoding_override_lookup(b"utf-8")
+        .parse("http://example.com/?例子").unwrap();
+    assert_eq!(url.query(), Some("%E4%BE%8B%E5%AD%90"));
+
+    let url = Url::options()
+        .encoding_override_lookup(b"gbk")
+        .parse("http://example.com/?例子").unwrap();
+    assert_eq!(url.query(), Some("%C0%FD%D7%D3"));
+
+    let url = Url::options()
+        .encoding_override_lookup(b"invalid label is ignored!")
+        .parse("http://example.com/?例子").unwrap();
+    assert_eq!(url.query(), Some("%E4%BE%8B%E5%AD%90"));
+}


### PR DESCRIPTION
Exposes an API that takes a `&[u8]` slice, instead of requiring the `rust-encoding` crate downstream for the `encoding::EncodingRef` type.

Helpful for https://github.com/servo/servo/issues/13238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/443)
<!-- Reviewable:end -->
