### PR TITLE
Avoid reparse issues with non-special URLs

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1057,6 +1057,17 @@ impl<'a> Parser<'a> {
                         }
                     }
                     if ends_with_slash {
+                        // This is a willfull violation of the URL specification for serialization.
+                        //
+                        // It aligns with the behaviour of Microsoft Edge,
+                        // it does not affect the result of parsing (that's still compliant),
+                        // and it's necessary to make URL reparsing idempotent.
+                        //
+                        // See the specification bug at https://github.com/whatwg/url/issues/415
+                        if !*has_host && &self.serialization[path_start..] == "/" {
+                            self.serialization.push('.');
+                            self.serialization.push('/');
+                        }
                         self.serialization.push('/')
                     }
                 }

--- a/tests/urltestdata.json
+++ b/tests/urltestdata.json
@@ -6144,5 +6144,20 @@
     "pathname": "/test",
     "search": "?a",
     "hash": "#bc"
+  },
+  "Found by fuzzing",
+  {
+    "input": "a:/a/..//a",
+    "base": "about:blank",
+    "href": "a:/.//a",
+    "protocol": "a:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "//a",
+    "search": "",
+    "hash": ""
   }
 ]


### PR DESCRIPTION
This avoids a contradiction where the URL starts out with no host, but gets normalized into a URL where the first part of a path is interpreted as the host.

Fixes #397

This is a willfull violation of the URL specification for serialization. It retains spec-compliance for parsing, it aligns with the behavior of Microsoft Edge, and it "fixes" an acknowledged specification bug.

See https://github.com/whatwg/url/issues/415

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/459)
<!-- Reviewable:end -->
