### PR TITLE
Add test case for ambiguous ipv6

### DIFF
--- a/tests/urltestdata.json
+++ b/tests/urltestdata.json
@@ -6144,5 +6144,10 @@
     "pathname": "/test",
     "search": "?a",
     "hash": "#bc"
+  },
+  {
+    "input": "f::some::ambiguous::ipv6",
+    "base": "http://example.org/foo/bar",
+    "failure": true
   }
 ]


### PR DESCRIPTION
I don't think this should be merged, because CI will fail, but it would be nice to start the conversation if this truly should be an error. Motivation is reducing false positives in https://github.com/jwilm/alacritty/issues/1727 .

If we determine it should be an error, I'd like to tackle fixing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/466)
<!-- Reviewable:end -->
