### PR TITLE
Add common traits to public types

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -146,7 +146,7 @@ impl<'a> Parse<'a> {
 }
 
 /// Like `Parse`, but yields pairs of `String` instead of pairs of `Cow<str>`.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct ParseIntoOwned<'a> {
     inner: Parse<'a>
 }
@@ -170,7 +170,7 @@ pub fn byte_serialize(input: &[u8]) -> ByteSerialize {
 }
 
 /// Return value of `byte_serialize()`.
-#[derive(Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub struct ByteSerialize<'a> {
     bytes: &'a [u8],
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -16,12 +16,18 @@ use parser::{ParseResult, ParseError};
 use percent_encoding::{percent_decode, utf8_percent_encode, SIMPLE_ENCODE_SET};
 use idna;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]
 pub enum HostInternal {
     None,
     Domain,
     Ipv4(Ipv4Addr),
     Ipv6(Ipv6Addr),
+}
+
+impl Default for HostInternal {
+    fn default() -> Self {
+        HostInternal::None
+    }
 }
 
 #[cfg(feature = "heapsize")]
@@ -70,7 +76,7 @@ impl<S> From<Host<S>> for HostInternal {
 }
 
 /// The host name of an URL.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub enum Host<S=String> {
     /// A DNS domain name, as '.' dot-separated labels.
     /// Non-ASCII labels are encoded in punycode per IDNA if this is the host of
@@ -195,7 +201,7 @@ impl<S: AsRef<str>> fmt::Display for Host<S> {
 
 /// This mostly exists because coherence rules don’t allow us to implement
 /// `ToSocketAddrs for (Host<S>, u16)`.
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub struct HostAndPort<S=String> {
     pub host: Host<S>,
     pub port: u16,
@@ -241,12 +247,12 @@ impl<S: AsRef<str>> ToSocketAddrs for HostAndPort<S> {
 }
 
 /// Socket addresses for an URL.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SocketAddrs {
     state: SocketAddrsState
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum SocketAddrsState {
     Domain(vec::IntoIter<SocketAddr>),
     One(SocketAddr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub mod form_urlencoded;
 #[doc(hidden)] pub mod quirks;
 
 /// A parsed URL record.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Url {
     /// Syntax in pseudo-BNF:
     ///
@@ -2422,7 +2422,7 @@ fn io_error<T>(reason: &str) -> io::Result<T> {
 }
 
 /// Implementation detail of `Url::query_pairs_mut`. Typically not used directly.
-#[derive(Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct UrlQuery<'a> {
     url: Option<&'a mut Url>,
     fragment: Option<String>,
@@ -2463,7 +2463,7 @@ impl<'a> Drop for UrlQuery<'a> {
 macro_rules! define_encode_set {
     ($(#[$attr: meta])* pub $name: ident = [$base_set: expr] | {$($ch: pat),*}) => {
         $(#[$attr])*
-        #[derive(Copy, Clone)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
         #[allow(non_camel_case_types)]
         pub struct $name;
 

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -50,7 +50,7 @@ pub fn url_origin(url: &Url) -> Origin {
 ///   the URL does not have the same origin as any other URL.
 ///
 /// For more information see <https://url.spec.whatwg.org/#origin>
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub enum Origin {
     /// A globally unique identifier
     Opaque(OpaqueOrigin),
@@ -123,7 +123,7 @@ impl Origin {
 }
 
 /// Opaque identifier for URLs that have file or other schemes
-#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub struct OpaqueOrigin(usize);
 
 #[cfg(feature = "heapsize")]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,7 +33,7 @@ pub type ParseResult<T> = Result<T, ParseError>;
 macro_rules! simple_enum_error {
     ($($name: ident => $description: expr,)+) => {
         /// Errors that can occur during parsing.
-        #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
         pub enum ParseError {
             $(
                 $name,
@@ -81,7 +81,7 @@ impl From<::idna::uts46::Errors> for ParseError {
 macro_rules! syntax_violation_enum {
     ($($name: ident => $description: expr,)+) => {
         /// Non-fatal syntax violations that can occur during parsing.
-        #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
         pub enum SyntaxViolation {
             $(
                 $name,
@@ -126,7 +126,7 @@ impl fmt::Display for SyntaxViolation {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub enum SchemeType {
     File,
     SpecialNotFile,
@@ -161,7 +161,7 @@ pub fn default_port(scheme: &str) -> Option<u16> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Input<'i> {
     chars: str::Chars<'i>,
 }
@@ -320,6 +320,7 @@ impl<'a> fmt::Debug for ViolationFn<'a> {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct Parser<'a> {
     pub serialization: String,
     pub base_url: Option<&'a Url>,
@@ -328,7 +329,7 @@ pub struct Parser<'a> {
     pub context: Context,
 }
 
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub enum Context {
     UrlParser,
     Setter,

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -33,7 +33,7 @@ use Url;
 /// # }
 /// # run().unwrap();
 /// ```
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash, Debug)]
 pub struct PathSegmentsMut<'a> {
     url: &'a mut Url,
     after_first_slash: usize,

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -33,7 +33,7 @@ use Url;
 /// # }
 /// # run().unwrap();
 /// ```
-#[derive(Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct PathSegmentsMut<'a> {
     url: &'a mut Url,
     after_first_slash: usize,

--- a/src/slicing.rs
+++ b/src/slicing.rs
@@ -77,7 +77,7 @@ impl Index<Range<Position>> for Url {
 /// `BeforeScheme` and `AfterFragment` are always the start and end of the entire URL,
 /// so `&url[BeforeScheme..X]` is the same as `&url[..X]`
 /// and `&url[X..AfterFragment]` is the same as `&url[X..]`.
-#[derive(Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub enum Position {
     BeforeScheme,
     AfterScheme,


### PR DESCRIPTION
Improves interoperability, making downstream manual implementation unnecessary.
rust-lang-nursery/api-guidelines
C-COMMON-TRAITS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/472)
<!-- Reviewable:end -->
