### PR TITLE
Redox support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2351,7 +2351,11 @@ fn file_url_segments_to_pathbuf(host: Option<&str>, segments: str::Split<char>) 
         return Err(());
     }
 
-    let mut bytes = Vec::new();
+    let mut bytes = if cfg!(target_os = "redox") {
+        b"file:".to_vec()
+    } else {
+        Vec::new()
+    };
     for segment in segments {
         bytes.push(b'/');
         bytes.extend(percent_decode(segment.as_bytes()));


### PR DESCRIPTION
Redox uses `file:` at the beginning of any file paths. Therefore, a path like `file:///home/user/some%20file.txt` needs to turn into `file:/home/user/some file.txt`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/477)
<!-- Reviewable:end -->
