### PR TITLE
Remove trailing question mark on empty query

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -372,7 +372,7 @@ impl<T: Target> Serializer<T> {
     ///     .append_pair("foo", "bar & baz")
     ///     .append_pair("saison", "Été+hiver")
     ///     .finish();
-    /// assert_eq!(encoded, "foo=bar+%26+baz&saison=%C3%89t%C3%A9%2Bhiver");
+    /// assert_eq!(encoded, "?foo=bar+%26+baz&saison=%C3%89t%C3%A9%2Bhiver");
     /// ```
     ///
     /// Panics if called more than once.

--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -384,6 +384,8 @@ impl<T: Target> Serializer<T> {
 fn append_separator_if_needed(string: &mut String, start_position: usize) {
     if string.len() > start_position {
         string.push('&')
+    } else if string.len() == start_position {
+        string.insert(start_position, '?')
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1327,8 +1327,7 @@ impl Url {
     /// # run().unwrap();
     /// ```
     ///
-    /// Note: `url.query_pairs_mut().clear();` is equivalent to `url.set_query(Some(""))`,
-    /// not `url.set_query(None)`.
+    /// Note: `url.query_pairs_mut().clear();` is equivalent to `url.set_query(None)`.
     ///
     /// The state of `Url` is unspecified if this return value is leaked without being dropped.
     pub fn query_pairs_mut(&mut self) -> form_urlencoded::Serializer<UrlQuery> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1336,16 +1336,14 @@ impl Url {
 
         let query_start;
         if let Some(start) = self.query_start {
-            debug_assert!(self.byte_at(start) == b'?');
             query_start = start as usize;
         } else {
             query_start = self.serialization.len();
             self.query_start = Some(to_u32(query_start).unwrap());
-            self.serialization.push('?');
         }
 
         let query = UrlQuery { url: Some(self), fragment: fragment };
-        form_urlencoded::Serializer::for_suffix(query, query_start + "?".len())
+        form_urlencoded::Serializer::for_suffix(query, query_start)
     }
 
     fn take_after_path(&mut self) -> String {

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -254,8 +254,8 @@ fn test_form_urlencoded() {
         ("foo".into(), "#".into())
     ];
     let encoded = form_urlencoded::Serializer::new(String::new()).extend_pairs(pairs).finish();
-    assert_eq!(encoded, "foo=%C3%A9%26&bar=&foo=%23");
-    assert_eq!(form_urlencoded::parse(encoded.as_bytes()).collect::<Vec<_>>(), pairs.to_vec());
+    assert_eq!(encoded, "?foo=%C3%A9%26&bar=&foo=%23");
+    assert_eq!(form_urlencoded::parse(&encoded.as_bytes()["?".len()..]).collect::<Vec<_>>(), pairs.to_vec());
 }
 
 #[test]
@@ -265,7 +265,7 @@ fn test_form_serialize() {
         .append_pair("bar", "")
         .append_pair("foo", "#")
         .finish();
-    assert_eq!(encoded, "foo=%C3%A9%26&bar=&foo=%23");
+    assert_eq!(encoded, "?foo=%C3%A9%26&bar=&foo=%23");
 }
 
 #[test]
@@ -274,7 +274,7 @@ fn form_urlencoded_custom_encoding_override() {
         .custom_encoding_override(|s| s.as_bytes().to_ascii_uppercase().into())
         .append_pair("foo", "bar")
         .finish();
-    assert_eq!(encoded, "FOO=BAR");
+    assert_eq!(encoded, "?FOO=BAR");
 }
 
 #[test]


### PR DESCRIPTION
Hello everyone!

I have been tinkering with the implementation of query_pairs_mut after looking at this [issue](https://github.com/seanmonstar/reqwest/issues/464) on the reqwest project. The core of the issue is that a serialization of an empty query insert a '?' at the end of the url.

 I went on to try and make the serialization of query_pairs_mut to only insert a trailing question mark after the first serialization. Making `url.query_pairs_mut().clear();` equivalent to `url.set_query(None)`.

I don't know if this behaviour is desired on the rust-url side, but would like to know if this change is feasible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/494)
<!-- Reviewable:end -->
