### PR TITLE
allowing bidi domain names to start with a digit

### DIFF
--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -130,7 +130,7 @@ fn passes_bidi(label: &str, is_bidi_domain: bool) -> bool {
 
     match first_char_class {
         // LTR label
-        BidiClass::L => {
+        BidiClass::L | BidiClass::EN => {
             // Rule 5
             loop {
                 match chars.next() {

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -226,6 +226,8 @@ fn test_idna() {
     assert!("http://goșu.ro".parse::<Url>().is_ok());
     assert_eq!(Url::parse("http://☃.net/").unwrap().host(), Some(Host::Domain("xn--n3h.net")));
     assert!("https://r2---sn-huoa-cvhl.googlevideo.com/crossdomain.xml".parse::<Url>().is_ok());
+    // https://github.com/servo/rust-url/issues/489
+    assert!("http://mail.163.com.xn----9mcjf9b4dbm09f.com/iloystgnjfrgthteawvo/indexx.php".parse::<Url>().is_ok());
 }
 
 #[test]


### PR DESCRIPTION
This pull request resolves the issue #489

Currently rust-url marks as invalid urls that contains bidirectional characters (domains that contain symbols both in RLT and LTR encoding) if they contains segments starting with a number.
As an example URL
http://mail.163.com.xn----9mcjf9b4dbm09f.com/iloystgnjfrgthteawvo/indexx.php
Attept to parse that url will return an error "invalid international domain name", while that url is valid and existed (url contained some malitious content and doesn't exist anymore)
While urls  http://mail.com.xn----9mcjf9b4dbm09f.com/iloystgnjfrgthteawvo/indexx.php as well as http://mail.163.com/iloystgnjfrgthteawvo/indexx.php are considered as OK. 
I guess there is some contradiction bettween different RFCs. This crate implements bidi (bidirectional unicode chars rules) check based on RFC-5893 https://tools.ietf.org/html/rfc5893#section-2 whicth says  that the first label in the segment name must be the left-to-right char, riht-to-left-char or "Arabic letter" but not "European Number"
While RFC-1123 from 1989 that specify "Requirements for Internet Hosts" explicily says that a digit is a permited domain name start https://tools.ietf.org/html/rfc1123#section-2
> the restriction on the first character is relaxed to allow either a
      letter or a digit.  Host software MUST support this more liberal
      syntax.

So, using using number starting subparts inside bidirectional subdomains sould be allowed, otherwise we sholud treat any number-started domain name (for example http://37signals.com/) as invalid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/496)
<!-- Reviewable:end -->
