### PR TITLE
Explicit unnamed member example

### DIFF
--- a/url_serde/src/lib.rs
+++ b/url_serde/src/lib.rs
@@ -27,6 +27,17 @@ struct MyStruct {
 }
 ```
 
+# How do I use a data type with an unnamed `Url` member with serde?
+
+Same problem, same solution.
+
+```
+#[derive(serde::Serialize, serde::Deserialize)]
+enum MyEnum {
+    A(#[serde(with = "url_serde")] Url, OtherType),
+}
+```
+
 # How do I encode a `Url` value with `serde_json::to_string`?
 
 Use the `Ser` wrapper.


### PR DESCRIPTION
Be a bit more explicit in the use of the `serde` attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/502)
<!-- Reviewable:end -->
