### PR TITLE
Remove the deprecated log_syntax_violation function for 2.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,20 +211,6 @@ impl<'a> ParseOptions<'a> {
         self
     }
 
-    /// Call the provided function or closure on non-fatal parse errors, passing
-    /// a static string description.  This method is deprecated in favor of
-    /// `syntax_violation_callback` and is implemented as an adaptor for the
-    /// latter, passing the `SyntaxViolation` description. Only the last value
-    /// passed to either method will be used by a parser.
-    #[deprecated]
-    pub fn log_syntax_violation(mut self, new: Option<&'a Fn(&'static str)>) -> Self {
-        self.violation_fn = match new {
-            Some(f) => ViolationFn::OldFn(f),
-            None => ViolationFn::NoOp
-        };
-        self
-    }
-
     /// Call the provided function or closure for a non-fatal `SyntaxViolation`
     /// when it occurs during parsing. Note that since the provided function is
     /// `Fn`, the caller might need to utilize _interior mutability_, such as with

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -275,7 +275,6 @@ impl<'i> Iterator for Input<'i> {
 #[derive(Copy, Clone)]
 pub enum ViolationFn<'a> {
     NewFn(&'a (Fn(SyntaxViolation) + 'a)),
-    OldFn(&'a (Fn(&'static str) + 'a)),
     NoOp
 }
 
@@ -284,7 +283,6 @@ impl<'a> ViolationFn<'a> {
     pub fn call(self, v: SyntaxViolation) {
         match self {
             ViolationFn::NewFn(f) => f(v),
-            ViolationFn::OldFn(f) => f(v.description()),
             ViolationFn::NoOp => {}
         }
     }
@@ -296,7 +294,6 @@ impl<'a> ViolationFn<'a> {
     {
         match self {
             ViolationFn::NewFn(f) => if test() { f(v) },
-            ViolationFn::OldFn(f) => if test() { f(v.description()) },
             ViolationFn::NoOp => {} // avoid test
         }
     }
@@ -314,7 +311,6 @@ impl<'a> fmt::Debug for ViolationFn<'a> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             ViolationFn::NewFn(_) => write!(f, "NewFn(Fn(SyntaxViolation))"),
-            ViolationFn::OldFn(_) => write!(f, "OldFn(Fn(&'static str))"),
             ViolationFn::NoOp     => write!(f, "NoOp")
         }
     }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -490,21 +490,6 @@ fn test_windows_unc_path() {
     assert!(url.is_err());
 }
 
-// Test the now deprecated log_syntax_violation method for backward
-// compatibility
-#[test]
-#[allow(deprecated)]
-fn test_old_log_violation_option() {
-    let violation = Cell::new(None);
-    let url = Url::options()
-        .log_syntax_violation(Some(&|s| violation.set(Some(s.to_owned()))))
-        .parse("http:////mozilla.org:42").unwrap();
-    assert_eq!(url.port(), Some(42));
-
-    let violation = violation.take();
-    assert_eq!(violation, Some("expected //".to_string()));
-}
-
 #[test]
 fn test_syntax_violation_callback() {
     use url::SyntaxViolation::*;


### PR DESCRIPTION
I've also removed the `OldFn` variant as that function was the only place that variant was constructed. Does it make sense to rename the `NewFn` variant to something else? Idk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/509)
<!-- Reviewable:end -->
