### PR TITLE
Fix warnings and increase MSRV for 2.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 
 jobs:
   include:
-  - rust: 1.17.0
+  - rust: 1.24.0
     install:
     # --precise requires Cargo.lock to already exist
     - cargo update
@@ -11,8 +11,7 @@ jobs:
 
     - cargo update -p unicode-normalization --precise 0.1.5
 
-    # data-url uses pub(crate) which is unstable in 1.17
-    script: cargo test --all-features -p url -p idna -p percent-encoding -p url_serde
+    script: cargo test --all-features -p url -p idna -p percent-encoding -p url_serde -p data-url
 
   - rust: stable
     script: cargo test --all-features --all

--- a/idna/src/punycode.rs
+++ b/idna/src/punycode.rs
@@ -15,8 +15,6 @@
 
 use std::u32;
 use std::char;
-#[allow(unused_imports, deprecated)]
-use std::ascii::AsciiExt;
 
 // Bootstring parameters for Punycode
 static BASE: u32 = 36;

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -11,8 +11,6 @@
 
 use self::Mapping::*;
 use punycode;
-#[allow(unused_imports, deprecated)]
-use std::ascii::AsciiExt;
 use std::cmp::Ordering::{Equal, Less, Greater};
 use unicode_bidi::{BidiClass, bidi_class};
 use unicode_normalization::UnicodeNormalization;

--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -32,7 +32,6 @@
 //! assert_eq!(utf8_percent_encode("foo bar?", DEFAULT_ENCODE_SET).to_string(), "foo%20bar%3F");
 //! ```
 
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt;
 use std::slice;

--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -55,7 +55,6 @@ pub fn parse_with_encoding<'a>(input: &'a [u8],
                                encoding_override: Option<::encoding::EncodingRef>,
                                use_charset: bool)
                                -> Result<Parse<'a>, ()> {
-    use std::ascii::AsciiExt;
 
     let mut encoding = EncodingOverride::from_opt_encoding(encoding_override);
     if !(encoding.is_utf8() || input.is_ascii()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2346,7 +2346,6 @@ fn path_to_file_url_segments_windows(path: &Path, serialization: &mut String)
 fn file_url_segments_to_pathbuf(host: Option<&str>, segments: str::Split<char>) -> Result<PathBuf, ()> {
     use std::ffi::OsStr;
     use std::os::unix::prelude::OsStrExt;
-    use std::path::PathBuf;
 
     if host.is_some() {
         return Err(());

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -10,7 +10,7 @@
 use host::Host;
 use idna::domain_to_unicode;
 use parser::default_port;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use Url;
 
 pub fn url_origin(url: &Url) -> Origin {
@@ -76,7 +76,7 @@ impl HeapSizeOf for Origin {
 impl Origin {
     /// Creates a new opaque origin that is only equal to itself.
     pub fn new_opaque() -> Origin {
-        static COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
         Origin::Opaque(OpaqueOrigin(COUNTER.fetch_add(1, Ordering::SeqCst)))
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,9 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(unused_imports, deprecated)]
-use std::ascii::AsciiExt;
-
 use std::error::Error;
 use std::fmt::{self, Formatter, Write};
 use std::str;

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -11,7 +11,6 @@
 #[macro_use]
 extern crate url;
 
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::net::{Ipv4Addr, Ipv6Addr};


### PR DESCRIPTION
This includes some warning fixes as well as a MSRV increase from 1.17.0 to 1.24.0 (which is the oldest release the replacements for the deprecated functionalities are available). The first commit should be least controversial as it doesn't require any MSRV increase. Please say whether MSRV increases are a problem, if they are I can put the first commit into a separate PR.

Fixes #455

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/510)
<!-- Reviewable:end -->
