### PR TITLE
Add unused variants to ParseError and SyntaxViolation enums

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,11 +49,17 @@ pub type ParseResult<T> = Result<T, ParseError>;
 macro_rules! simple_enum_error {
     ($($name: ident => $description: expr,)+) => {
         /// Errors that can occur during parsing.
+        ///
+        /// This may be extended in the future so exhaustive matching is
+        /// discouraged with an unused variant.
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         pub enum ParseError {
             $(
                 $name,
             )+
+            /// Unused variant enable non-exhaustive matching
+            #[doc(hidden)]
+            __FutureProof,
         }
 
         impl Error for ParseError {
@@ -62,6 +68,9 @@ macro_rules! simple_enum_error {
                     $(
                         ParseError::$name => $description,
                     )+
+                    ParseError::__FutureProof => {
+                        unreachable!("Don't abuse the FutureProof!");
+                    }
                 }
             }
         }
@@ -96,11 +105,17 @@ impl From<::idna::Errors> for ParseError {
 macro_rules! syntax_violation_enum {
     ($($name: ident => $description: expr,)+) => {
         /// Non-fatal syntax violations that can occur during parsing.
+        ///
+        /// This may be extended in the future so exhaustive matching is
+        /// discouraged with an unused variant.
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         pub enum SyntaxViolation {
             $(
                 $name,
             )+
+            /// Unused variant enable non-exhaustive matching
+            #[doc(hidden)]
+            __FutureProof,
         }
 
         impl SyntaxViolation {
@@ -109,6 +124,9 @@ macro_rules! syntax_violation_enum {
                     $(
                         SyntaxViolation::$name => $description,
                     )+
+                    SyntaxViolation::__FutureProof => {
+                        unreachable!("Don't abuse the FutureProof!");
+                    }
                 }
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -91,8 +91,8 @@ simple_enum_error! {
 }
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        self.description().fmt(fmt)
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.description(), f)
     }
 }
 
@@ -151,8 +151,8 @@ syntax_violation_enum! {
 }
 
 impl fmt::Display for SyntaxViolation {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        self.description().fmt(fmt)
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.description(), f)
     }
 }
 

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -512,6 +512,7 @@ fn test_syntax_violation_callback() {
     let v = violation.take().unwrap();
     assert_eq!(v, ExpectedDoubleSlash);
     assert_eq!(v.description(), "expected //");
+    assert_eq!(v.to_string(), "expected //");
 }
 
 #[test]


### PR DESCRIPTION
Per discussion in https://github.com/servo/rust-url/issues/498#issuecomment-513299432 , this adds a hidden unused variant to each of `ParseError` and `SyntaxViolation` enums so as to make future additions non-breaking changes.   This is the long standing manual way (e.g. originally used by`std::io::ErrorKind`), given lack of a stable feature and acceptable rust MSRV with rust-lang/rust#44109.

Also these types already implemented `Display` but having been burnt with `Debug` vs `Display` versions of the `fmt` function, I also disambiguated paths in these `Display` implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/525)
<!-- Reviewable:end -->
