### PR TITLE
Remove redundant field names in struct init

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -27,7 +27,7 @@ use std::str;
 /// converted to `[("#first", "%try%")]`.
 #[inline]
 pub fn parse(input: &[u8]) -> Parse {
-    Parse { input: input }
+    Parse { input }
 }
 /// The return type of `parse()`.
 #[derive(Copy, Clone)]
@@ -233,7 +233,7 @@ impl<'a, T: Target> Serializer<'a, T> {
         &target.as_mut_string()[start_position..]; // Panic if out of bounds
         Serializer {
             target: Some(target),
-            start_position: start_position,
+            start_position,
             encoding: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1282,7 +1282,7 @@ impl Url {
 
         let query = UrlQuery {
             url: Some(self),
-            fragment: fragment,
+            fragment,
         };
         form_urlencoded::Serializer::for_suffix(query, query_start + "?".len())
     }
@@ -1984,12 +1984,12 @@ impl Url {
         let host_start = serialization.len() as u32;
         let (host_end, host) = path_to_file_url_segments(path.as_ref(), &mut serialization)?;
         Ok(Url {
-            serialization: serialization,
+            serialization,
             scheme_end: "file".len() as u32,
             username_end: host_start,
-            host_start: host_start,
-            host_end: host_end,
-            host: host,
+            host_start,
+            host_end,
+            host,
             port: None,
             path_start: host_end,
             query_start: None,
@@ -2091,16 +2091,16 @@ impl Url {
             fragment_start,
         ) = Deserialize::deserialize(deserializer)?;
         let url = Url {
-            serialization: serialization,
-            scheme_end: scheme_end,
-            username_end: username_end,
-            host_start: host_start,
-            host_end: host_end,
-            host: host,
-            port: port,
-            path_start: path_start,
-            query_start: query_start,
-            fragment_start: fragment_start,
+            serialization,
+            scheme_end,
+            username_end,
+            host_start,
+            host_end,
+            host,
+            port,
+            path_start,
+            query_start,
+            fragment_start,
         };
         if cfg!(debug_assertions) {
             url.check_invariants().map_err(|reason| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -323,7 +323,7 @@ impl<'a> Parser<'a> {
 
     pub fn for_setter(serialization: String) -> Parser<'a> {
         Parser {
-            serialization: serialization,
+            serialization,
             base_url: None,
             query_encoding_override: None,
             violation_fn: None,
@@ -496,13 +496,13 @@ impl<'a> Parser<'a> {
                     let path_start = "file://".len() as u32;
                     Ok(Url {
                         serialization: self.serialization,
-                        scheme_end: scheme_end,
+                        scheme_end,
                         username_end: path_start,
                         host_start: path_start,
                         host_end: path_start,
                         host: HostInternal::None,
                         port: None,
-                        path_start: path_start,
+                        path_start,
                         query_start: None,
                         fragment_start: None,
                     })
@@ -520,8 +520,8 @@ impl<'a> Parser<'a> {
                         self.parse_query_and_fragment(scheme_type, base_url.scheme_end, input)?;
                     Ok(Url {
                         serialization: self.serialization,
-                        query_start: query_start,
-                        fragment_start: fragment_start,
+                        query_start,
+                        fragment_start,
                         ..*base_url
                     })
                 } else {
@@ -532,15 +532,15 @@ impl<'a> Parser<'a> {
                         self.parse_query_and_fragment(scheme_type, scheme_end, input)?;
                     Ok(Url {
                         serialization: self.serialization,
-                        scheme_end: scheme_end,
+                        scheme_end,
                         username_end: path_start,
                         host_start: path_start,
                         host_end: path_start,
                         host: HostInternal::None,
                         port: None,
-                        path_start: path_start,
-                        query_start: query_start,
-                        fragment_start: fragment_start,
+                        path_start,
+                        query_start,
+                        fragment_start,
                     })
                 }
             }
@@ -556,13 +556,13 @@ impl<'a> Parser<'a> {
                     self.parse_fragment(input_after_first_char);
                     Ok(Url {
                         serialization: self.serialization,
-                        scheme_end: scheme_end,
+                        scheme_end,
                         username_end: path_start,
                         host_start: path_start,
                         host_end: path_start,
                         host: HostInternal::None,
                         port: None,
-                        path_start: path_start,
+                        path_start,
                         query_start: None,
                         fragment_start: Some(fragment_start),
                     })
@@ -601,15 +601,15 @@ impl<'a> Parser<'a> {
                         self.parse_query_and_fragment(scheme_type, scheme_end, remaining)?;
                     Ok(Url {
                         serialization: self.serialization,
-                        scheme_end: scheme_end,
+                        scheme_end,
                         username_end: host_start,
-                        host_start: host_start,
-                        host_end: host_end,
-                        host: host,
+                        host_start,
+                        host_end,
+                        host,
                         port: None,
                         path_start: host_end,
-                        query_start: query_start,
-                        fragment_start: fragment_start,
+                        query_start,
+                        fragment_start,
                     })
                 } else {
                     self.serialization.push_str("file:///");
@@ -634,15 +634,15 @@ impl<'a> Parser<'a> {
                     let path_start = path_start as u32;
                     Ok(Url {
                         serialization: self.serialization,
-                        scheme_end: scheme_end,
+                        scheme_end,
                         username_end: path_start,
                         host_start: path_start,
                         host_end: path_start,
                         host: HostInternal::None,
                         port: None,
-                        path_start: path_start,
-                        query_start: query_start,
-                        fragment_start: fragment_start,
+                        path_start,
+                        query_start,
+                        fragment_start,
                     })
                 }
             }
@@ -685,15 +685,15 @@ impl<'a> Parser<'a> {
                     let path_start = path_start as u32;
                     Ok(Url {
                         serialization: self.serialization,
-                        scheme_end: scheme_end,
+                        scheme_end,
                         username_end: path_start,
                         host_start: path_start,
                         host_end: path_start,
                         host: HostInternal::None,
                         port: None,
-                        path_start: path_start,
-                        query_start: query_start,
-                        fragment_start: fragment_start,
+                        path_start,
+                        query_start,
+                        fragment_start,
                     })
                 }
             }
@@ -734,8 +734,8 @@ impl<'a> Parser<'a> {
                     self.parse_query_and_fragment(scheme_type, base_url.scheme_end, input)?;
                 Ok(Url {
                     serialization: self.serialization,
-                    query_start: query_start,
-                    fragment_start: fragment_start,
+                    query_start,
+                    fragment_start,
                     ..*base_url
                 })
             }
@@ -1211,15 +1211,15 @@ impl<'a> Parser<'a> {
             self.parse_query_and_fragment(scheme_type, scheme_end, remaining)?;
         Ok(Url {
             serialization: self.serialization,
-            scheme_end: scheme_end,
-            username_end: username_end,
-            host_start: host_start,
-            host_end: host_end,
-            host: host,
-            port: port,
-            path_start: path_start,
-            query_start: query_start,
-            fragment_start: fragment_start,
+            scheme_end,
+            username_end,
+            host_start,
+            host_end,
+            host,
+            port,
+            path_start,
+            query_start,
+            fragment_start,
         })
     }
 

--- a/src/path_segments.rs
+++ b/src/path_segments.rs
@@ -48,9 +48,9 @@ pub fn new(url: &mut Url) -> PathSegmentsMut {
     debug_assert!(url.byte_at(url.path_start) == b'/');
     PathSegmentsMut {
         after_first_slash: url.path_start as usize + "/".len(),
-        url: url,
-        old_after_path_position: old_after_path_position,
-        after_path: after_path,
+        url,
+        old_after_path_position,
+        after_path,
     }
 }
 


### PR DESCRIPTION
Besides the obvious minimization, these changes avoid lints of the following form from clippy:

``` txt
    warning: redundant field names in struct initialization
      --> src/form_urlencoded.rs:30:13
       |
    30 |     Parse { input: input }
       |             ^^^^^^^^^^^^ help: replace it with: `input`
       |
       = help: for further information visit
    https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/526)
<!-- Reviewable:end -->
