### PR TITLE
percent-encoding: Allow to remove character from AsciiSet

### DIFF
--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percent-encoding"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["The rust-url developers"]
 description = "Percent encoding and decoding"
 repository = "https://github.com/servo/rust-url/"

--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -83,6 +83,12 @@ impl AsciiSet {
         mask[byte as usize / BITS_PER_CHUNK] |= 1 << (byte as usize % BITS_PER_CHUNK);
         AsciiSet { mask }
     }
+
+    pub const fn remove(&self, byte: u8) -> Self {
+        let mut mask = self.mask;
+        mask[byte as usize / BITS_PER_CHUNK] &= !(1 << (byte as usize % BITS_PER_CHUNK));
+        AsciiSet { mask }
+    }
 }
 
 /// The set of 0x00 to 0x1F (C0 controls), and 0x7F (DEL).

--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -68,7 +68,7 @@ const BITS_PER_CHUNK: usize = 8 * std::mem::size_of::<Chunk>();
 impl AsciiSet {
     /// Called with UTF-8 bytes rather than code points.
     /// Not used for non-ASCII bytes.
-    pub const fn contains(&self, byte: u8) -> bool {
+    const fn contains(&self, byte: u8) -> bool {
         let chunk = self.mask[byte as usize / BITS_PER_CHUNK];
         let mask = 1 << (byte as usize % BITS_PER_CHUNK);
         (chunk & mask) != 0

--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -68,7 +68,7 @@ const BITS_PER_CHUNK: usize = 8 * std::mem::size_of::<Chunk>();
 impl AsciiSet {
     /// Called with UTF-8 bytes rather than code points.
     /// Not used for non-ASCII bytes.
-    const fn contains(&self, byte: u8) -> bool {
+    pub const fn contains(&self, byte: u8) -> bool {
         let chunk = self.mask[byte as usize / BITS_PER_CHUNK];
         let mask = 1 << (byte as usize % BITS_PER_CHUNK);
         (chunk & mask) != 0


### PR DESCRIPTION
Allow to remove character from AsciiSet

I liked trait approach better, but if you're going with something like AsciiSet it would be better to allow to remove bytes, as sometimes it is easier to take `NON_ALPHANUMERIC` and remove few necessary characters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/528)
<!-- Reviewable:end -->
