### PR TITLE
form-urlencoded: Allow to encode key parameters without a values

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -309,7 +309,7 @@ impl<'a, T: Target> Serializer<'a, T> {
         self
     }
 
-    /// Serialize and append a number of name/value pairs.
+    /// Serialize and append a number of names without values.
     ///
     /// This simply calls `append_key_only` repeatedly.
     /// This can be more convenient, so the user doesn’t need to introduce a block

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -315,8 +315,9 @@ fn test_form_serialize() {
         .append_pair("foo", "é&")
         .append_pair("bar", "")
         .append_pair("foo", "#")
+        .append_key_only("json")
         .finish();
-    assert_eq!(encoded, "foo=%C3%A9%26&bar=&foo=%23");
+    assert_eq!(encoded, "foo=%C3%A9%26&bar=&foo=%23&json");
 }
 
 #[test]
@@ -324,8 +325,9 @@ fn form_urlencoded_encoding_override() {
     let encoded = form_urlencoded::Serializer::new(String::new())
         .encoding_override(Some(&|s| s.as_bytes().to_ascii_uppercase().into()))
         .append_pair("foo", "bar")
+        .append_key_only("xml")
         .finish();
-    assert_eq!(encoded, "FOO=BAR");
+    assert_eq!(encoded, "FOO=BAR&XML");
 }
 
 #[test]


### PR DESCRIPTION
According to [#546](https://github.com/servo/rust-url/issues/546#issue-493793309)
Add methods:
    - Serializer<UrlQuery>::append_key_only(&mut self, name: &str) -> &mut Self;
    - Serializer<UrlQuery>::extend_keys_only<I, K>(&mut self, iter: I) -> &mut Self;
in order to allow query parameters without a values like:
    - https://example.org/exchange?date=20190915&json
    - https://example.org/exchange?date=20190915&xml
    - https://example.org/exchange?date=20190915&bin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/547)
<!-- Reviewable:end -->
