### PR TITLE
Make EncodingOverride Send + Sync so that form_urlencoded::Serializer is as well

### DIFF
--- a/src/query_encoding.rs
+++ b/src/query_encoding.rs
@@ -8,7 +8,7 @@
 
 use std::borrow::Cow;
 
-pub type EncodingOverride<'a> = Option<&'a dyn Fn(&str) -> Cow<[u8]>>;
+pub type EncodingOverride<'a> = Option<&'a (dyn Fn(&str) -> Cow<[u8]> + Send + Sync)>;
 
 pub(crate) fn encode<'a>(encoding_override: EncodingOverride, input: &'a str) -> Cow<'a, [u8]> {
     if let Some(o) = encoding_override {


### PR DESCRIPTION
Without this, `form_urlencoded::Serializer` _usually_ can't cross `await` points in async code, making it harder to use.

Unfortunately I think this is a major change, so please advice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-url/550)
<!-- Reviewable:end -->
