### PR TITLE
[idna] Bump unicode-normalization to 0.1.9

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -24,5 +24,5 @@ serde_json = "1.0"
 
 [dependencies]
 unicode-bidi = "0.3"
-unicode-normalization = "0.1.5"
+unicode-normalization = "0.1.9"
 matches = "0.1"


### PR DESCRIPTION
With https://github.com/unicode-rs/unicode-normalization/pull/37 landing, this should help with compilation times and sizes (https://github.com/servo/rust-url/issues/557)