### PR TITLE
Make percent-encoding no_std-compatible

### DIFF
--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -9,3 +9,7 @@ license = "MIT/Apache-2.0"
 [lib]
 test = false
 path = "lib.rs"
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
This makes the library no_std-compatible in a pretty straightforward manner by disabling methods that can't possibly work in a no_std environment (like Cow and dynamic string allocation)

As a second step, this could be made alloc-enabled but that is not needed for my use-case.