### PR TITLE
added doc assert_eq to show what parse_with_params does

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -277,6 +277,7 @@ impl Url {
     /// # fn run() -> Result<(), ParseError> {
     /// let url = Url::parse_with_params("https://example.net?dont=clobberme",
     ///                                  &[("lang", "rust"), ("browser", "servo")])?;
+    /// assert_eq!("https://example.net/?dont=clobberme&lang=rust&browser=servo", url.as_str());
     /// # Ok(())
     /// # }
     /// # run().unwrap();


### PR DESCRIPTION
Just wanted this when i looked at the documentation.