### PR TITLE
impl TryFrom<'a str> for Url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ harness = false
 [lib]
 test = false
 
-[features]
-try_from = []
-
 [dev-dependencies]
 rustc-test = "0.3"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ harness = false
 [lib]
 test = false
 
+[features]
+try_from = []
+
 [dev-dependencies]
 rustc-test = "0.3"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,6 @@ use std::ops::{Range, RangeFrom, RangeTo};
 use std::path::{Path, PathBuf};
 use std::str;
 
-#[cfg(feature = "try_from")]
 use std::convert::TryFrom;
 
 pub use host::Host;
@@ -2231,7 +2230,6 @@ impl str::FromStr for Url {
     }
 }
 
-#[cfg(feature = "try_from")]
 impl<'a> TryFrom<&'a str> for Url {
     type Error = ParseError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,9 @@ use std::ops::{Range, RangeFrom, RangeTo};
 use std::path::{Path, PathBuf};
 use std::str;
 
+#[cfg(feature = "try_from")]
+use std::convert::TryFrom;
+
 pub use host::Host;
 pub use origin::{OpaqueOrigin, Origin};
 pub use parser::{ParseError, SyntaxViolation};
@@ -2225,6 +2228,15 @@ impl str::FromStr for Url {
     #[inline]
     fn from_str(input: &str) -> Result<Url, ::ParseError> {
         Url::parse(input)
+    }
+}
+
+#[cfg(feature = "try_from")]
+impl<'a> TryFrom<&'a str> for Url {
+    type Error = ParseError;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Url::parse(s)
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/servo/rust-url/issues/568. Implements `TryFrom<'a str> for Url` gated behind the `try_from` feature. This should make it possible to use this conversion without issuing a breaking change. Thanks!