### PR TITLE
Increment MSVR to 1.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script: cargo test --all-features --all
 
 jobs:
   include:
-  - rust: 1.33.0
+  - rust: 1.36.0
   - rust: stable
   - rust: beta
   - rust: nightly


### PR DESCRIPTION
… because `unicode-normalization` did.

Fixes https://github.com/servo/rust-url/issues/566
Closes https://github.com/servo/rust-url/pull/572