### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -62,7 +62,7 @@ macro_rules! simple_enum_error {
             __FutureProof,
         }
 
-        impl Error for ParseError {
+        impl ParseError {
             fn description(&self) -> &str {
                 match *self {
                     $(
@@ -74,6 +74,8 @@ macro_rules! simple_enum_error {
                 }
             }
         }
+
+        impl Error for ParseError {}
     }
 }
 


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Moves an implementation of `Error::description` into internal `ParseError` type implementation similar to `SyntaxViolation`

Related PR: https://github.com/rust-lang/rust/pull/66919