### PR TITLE
Update version to 2.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "url"
 # When updating version, also modify html_root_url in the lib.rs
-version = "2.1.0"
+version = "2.1.1"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"
@@ -39,7 +39,7 @@ bencher = "0.1"
 [dependencies]
 idna = { version = "0.2.0", path = "./idna" }
 matches = "0.1"
-percent-encoding = { version = "2.0.0", path = "./percent_encoding" }
+percent-encoding = { version = "2.1.0", path = "./percent_encoding" }
 serde = {version = "1.0", optional = true, features = ["derive"]}
 
 [[bench]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css");
 # run().unwrap();
 */
 
-#![doc(html_root_url = "https://docs.rs/url/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/url/2.1.1")]
 
 #[macro_use]
 extern crate matches;


### PR DESCRIPTION
PR #537 fixed a large number of issues which affected compliance
with the URL spec. We should release a new crate version with
these changes.