### PR TITLE
decode: Use assert to ensure unsafety constraints

### DIFF
--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -434,7 +434,7 @@ fn decode_utf8_lossy(input: Cow<[u8]>) -> Cow<str> {
                 Cow::Owned(s) => return s.into(),
             }
             // from_utf8_lossy returned a borrow of `bytes` unchanged.
-            debug_assert!(raw_utf8 == &*bytes as *const [u8]);
+            assert!(raw_utf8 == &*bytes as *const [u8]);
             // Reuse the existing `Vec` allocation.
             unsafe { String::from_utf8_unchecked(bytes) }.into()
         }


### PR DESCRIPTION
The unsafe from_utf8_unchecked call in decude_utf8_lossy relies on bytes to contain only valid bytes.

The from_utf8_lossy function used in there does not guarantee that it never returns a Borrowed() with foreigh data -- it currently does not, but it might (without violating its type constraints, and technically without even changing the documentation) start returning a `Borrowed(&'static "�")` if the complete string is deemed invalid.

With no guarantees that this does not happen, and an unsafe that relies on them, a strong assert is required, rather than the lax debug_assert that'd only trigger in debug builds.

If it is anticipated that from_utf_lossy would actually ever change in such a way, it should be possible to rewrite the code to check the condition inside the match branch (which would need to clone that slice then, as it couldn't know that there's actually a &'static in there) -- but I consider this unlikely.