### PR TITLE
decode size hint: Fix lower boundary

### DIFF
--- a/percent_encoding/lib.rs
+++ b/percent_encoding/lib.rs
@@ -368,7 +368,7 @@ impl<'a> Iterator for PercentDecode<'a> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let bytes = self.bytes.len();
-        (bytes / 3, Some(bytes))
+        ((bytes + 2) / 3, Some(bytes))
     }
 }
 


### PR DESCRIPTION
The size of a decoded URI can shrink only in fixed steps of 3 byte ("%xx") to 1 byte, thus the resulting size is always rounded up (2 bytes can not shrink any further), which is most easily implemented in integer division by adding `divisor - 1`.

---

Admittedly, this is not expected to make much difference; primarily it makes the implementation precise. Feel free to reject this if the overhead is not worth it. (Given this stems from a random crev crate review and not a practical problem).