### PR TITLE
Feature: dynamically-typed form parser selection

### DIFF
--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -98,7 +98,7 @@ fn replace_plus(input: &[u8]) -> Cow<[u8]> {
     }
 }
 
-impl<'a, K: Clone, V: Clone> Parse<'a, K, V> {
+impl<'a, K, V> Parse<'a, K, V> {
     /// Return a new iterator that yields pairs of `String` instead of pairs of `Cow<str>`.
     pub fn into_owned(self) -> ParseIntoOwned<'a, K, V> {
         ParseIntoOwned { inner: self }

--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -116,15 +116,15 @@ pub struct ParseIntoOwned<'a, K, V> {
 
 impl<'a, K, V> Iterator for ParseIntoOwned<'a, K, V>
 where
-    K: ToString,
-    V: ToString,
+    K: ToOwned + ToString,
+    V: ToOwned + ToString,
 {
     type Item = (String, String);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .map(|(k, v)| (k.to_owned().to_string(), v.to_owned().to_string()))
     }
 }
 

--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -32,11 +32,24 @@ pub fn parse<K, V>(input: &[u8]) -> Parse<K, V> {
 }
 
 /// The return type of `parse()`.
-#[derive(Copy, Clone)]
+/// todo(uncomment): #[derive(Copy, Clone)]
 pub struct Parse<'a, K, V> {
     input: &'a [u8],
     phantom: PhantomData<(K, V)>,
 }
+
+/// todo(delete): Workaround for derive() issues
+/// https://github.com/rust-lang/rust/issues/26925
+impl <K, V> Clone for Parse<'_, K, V>
+{
+    fn clone(&self) -> Self {
+        Parse {
+            input: self.input.clone(),
+            phantom: self.phantom.clone(),
+        }
+    }
+}
+impl <K, V> Copy for Parse<'_, K, V> {}
 
 impl<'a, K: ToString, V: ToString> Iterator for Parse<'a, K, V> {
     type Item = (Cow<'a, str>, Cow<'a, str>);

--- a/src/form_urlencoded.rs
+++ b/src/form_urlencoded.rs
@@ -51,7 +51,11 @@ impl <K, V> Clone for Parse<'_, K, V>
 }
 impl <K, V> Copy for Parse<'_, K, V> {}
 
-impl<'a, K: ToString, V: ToString> Iterator for Parse<'a, K, V> {
+impl<'a, K, V> Iterator for Parse<'a, K, V>
+where
+    K: ToString,
+    V: ToString,
+{
     type Item = (Cow<'a, str>, Cow<'a, str>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -110,7 +114,11 @@ pub struct ParseIntoOwned<'a, K, V> {
     inner: Parse<'a, K, V>,
 }
 
-impl<'a, K: ToString, V: ToString> Iterator for ParseIntoOwned<'a, K, V> {
+impl<'a, K, V> Iterator for ParseIntoOwned<'a, K, V>
+where
+    K: ToString,
+    V: ToString,
+{
     type Item = (String, String);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ extern crate serde;
 use host::HostInternal;
 use parser::{to_u32, Context, Parser, SchemeType, PATH_SEGMENT, USERINFO};
 use percent_encoding::{percent_decode, percent_encode, utf8_percent_encode};
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::cmp;
 #[cfg(feature = "serde")]
 use std::error::Error;
@@ -1153,7 +1153,7 @@ impl Url {
     ///
 
     #[inline]
-    pub fn query_pairs(&self) -> form_urlencoded::Parse {
+    pub fn query_pairs(&self) -> form_urlencoded::Parse<Cow<'_, str>, Cow<'_, str>> {
         form_urlencoded::parse(self.query().unwrap_or("").as_bytes())
     }
 

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -347,7 +347,7 @@ fn test_form_urlencoded() {
         .finish();
     assert_eq!(encoded, "foo=%C3%A9%26&bar=&foo=%23");
     assert_eq!(
-        form_urlencoded::parse(encoded.as_bytes()).collect::<Vec<_>>(),
+        form_urlencoded::parse::<Cow<'_, str>, Cow<'_, str>>(encoded.as_bytes()).collect::<Vec<_>>(),
         pairs.to_vec()
     );
 }


### PR DESCRIPTION
While developing #591, there was a long period of time during which I had hoped to maintain all (or almost all) call interfaces for backwards compatibility reasons.

During attempts to achieve that, I discovered the [`ParseIntoOwned`](https://github.com/servo/rust-url/blob/28314752bf138a87bd8151f610d385629dec5710/src/form_urlencoded.rs#L92-L95) struct, and wondered whether it'd be possible to use Rust's [`impl trait`](https://doc.rust-lang.org/stable/rust-by-example/trait/impl_trait.html) feature to determine an appropriate parser based on the call-site's typing information.

I didn't quite manage to get this working, and should likely move on to other tasks - so I'm opening these changes in case they're useful in future.