### PR TITLE
Updated Cargo.toml with new libfuzzer dependency.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,10 +8,11 @@ publish = false
 [package.metadata]
 cargo-fuzz = true
 
+[dependencies]
+libfuzzer-sys = "0.3"
+
 [dependencies.url]
 path = ".."
-[dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 
 [[bin]]
 name = "parse"


### PR DESCRIPTION
This commit is necessary for OSS-Fuzz integration. 
OSS-Fuzz integration was discussed with @valenting by email. 