### PR TITLE
Make crate about 50% lighter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["url", "parser"]
 categories = ["parser-implementations", "web-programming", "encoding"]
 license = "MIT/Apache-2.0"
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [badges]
 travis-ci = { repository = "servo/rust-url" }


### PR DESCRIPTION
According to cargo-diet:

> Saved 54% or 250.1 KB in 9 files (of 466.0 KB and 22 files in entire crate)