### PR TITLE
idna maintenance and performance improvements

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -19,6 +19,7 @@ harness = false
 name = "unit"
 
 [dev-dependencies]
+assert_matches = "1.3"
 bencher = "0.1"
 rustc-test = "0.3"
 serde_json = "1.0"

--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -38,7 +38,7 @@ extern crate matches;
 pub mod punycode;
 mod uts46;
 
-pub use crate::uts46::{Config, Errors};
+pub use crate::uts46::{Codec, Config, Errors};
 
 /// The [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii) algorithm.
 ///

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -82,38 +82,65 @@ fn find_char(codepoint: char) -> &'static Mapping {
         .unwrap()
 }
 
-fn map_char(codepoint: char, config: Config, output: &mut String, errors: &mut Vec<Error>) {
-    if let '.' | '-' | 'a'..='z' | '0'..='9' = codepoint {
-        output.push(codepoint);
-        return;
-    }
+struct Mapper<'a> {
+    chars: std::str::Chars<'a>,
+    config: Config,
+    errors: &'a mut Vec<Error>,
+    slice: Option<std::str::Chars<'static>>,
+}
 
-    match *find_char(codepoint) {
-        Mapping::Valid => output.push(codepoint),
-        Mapping::Ignored => {}
-        Mapping::Mapped(ref slice) => output.push_str(decode_slice(slice)),
-        Mapping::Deviation(ref slice) => {
-            if config.transitional_processing {
-                output.push_str(decode_slice(slice))
-            } else {
-                output.push(codepoint)
+impl<'a> Iterator for Mapper<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(s) = &mut self.slice {
+                match s.next() {
+                    Some(c) => return Some(c),
+                    None => {
+                        self.slice = None;
+                    }
+                }
             }
-        }
-        Mapping::Disallowed => {
-            errors.push(Error::DisallowedCharacter);
-            output.push(codepoint);
-        }
-        Mapping::DisallowedStd3Valid => {
-            if config.use_std3_ascii_rules {
-                errors.push(Error::DisallowedByStd3AsciiRules);
+
+            let codepoint = self.chars.next()?;
+            if let '.' | '-' | 'a'..='z' | '0'..='9' = codepoint {
+                return Some(codepoint);
             }
-            output.push(codepoint)
-        }
-        Mapping::DisallowedStd3Mapped(ref slice) => {
-            if config.use_std3_ascii_rules {
-                errors.push(Error::DisallowedMappedInStd3);
-            }
-            output.push_str(decode_slice(slice))
+
+            return Some(match *find_char(codepoint) {
+                Mapping::Valid => codepoint,
+                Mapping::Ignored => continue,
+                Mapping::Mapped(ref slice) => {
+                    self.slice = Some(decode_slice(slice).chars());
+                    continue;
+                }
+                Mapping::Deviation(ref slice) => {
+                    if self.config.transitional_processing {
+                        self.slice = Some(decode_slice(slice).chars());
+                        continue;
+                    } else {
+                        codepoint
+                    }
+                }
+                Mapping::Disallowed => {
+                    self.errors.push(Error::DisallowedCharacter);
+                    codepoint
+                }
+                Mapping::DisallowedStd3Valid => {
+                    if self.config.use_std3_ascii_rules {
+                        self.errors.push(Error::DisallowedByStd3AsciiRules);
+                    };
+                    codepoint
+                }
+                Mapping::DisallowedStd3Mapped(ref slice) => {
+                    if self.config.use_std3_ascii_rules {
+                        self.errors.push(Error::DisallowedMappedInStd3);
+                    };
+                    self.slice = Some(decode_slice(slice).chars());
+                    continue;
+                }
+            });
         }
     }
 }
@@ -334,12 +361,15 @@ fn processing(domain: &str, config: Config, errors: &mut Vec<Error>) -> String {
         return domain.to_owned();
     }
 
-    let mut mapped = String::with_capacity(domain.len());
-    for c in domain.chars() {
-        map_char(c, config, &mut mapped, errors)
-    }
-    let mut normalized = String::with_capacity(mapped.len());
-    normalized.extend(mapped.nfc());
+    let iter = Mapper {
+        chars: domain.chars(),
+        config,
+        errors,
+        slice: None,
+    };
+
+    let mut normalized = String::with_capacity(domain.len());
+    normalized.extend(iter.nfc());
 
     let mut validated = String::new();
     let non_transitional = config.transitional_processing(false);

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -325,7 +325,13 @@ fn is_valid(label: &str, config: Config) -> bool {
 }
 
 /// http://www.unicode.org/reports/tr46/#Processing
-fn processing(domain: &str, config: Config, errors: &mut Vec<Error>) -> String {
+fn processing(
+    domain: &str,
+    config: Config,
+    normalized: &mut String,
+    output: &mut String,
+    errors: &mut Vec<Error>,
+) {
     // Weed out the simple cases: only allow all lowercase ASCII characters and digits where none
     // of the labels start with PUNYCODE_PREFIX and labels don't start or end with hyphen.
     let (mut prev, mut simple, mut puny_prefix) = ('?', !domain.is_empty(), 0);
@@ -358,8 +364,13 @@ fn processing(domain: &str, config: Config, errors: &mut Vec<Error>) -> String {
         prev = c;
     }
     if simple {
-        return domain.to_owned();
+        output.push_str(domain);
+        return;
     }
+
+    normalized.clear();
+    errors.clear();
+    let offset = output.len();
 
     let iter = Mapper {
         chars: domain.chars(),
@@ -368,24 +379,22 @@ fn processing(domain: &str, config: Config, errors: &mut Vec<Error>) -> String {
         slice: None,
     };
 
-    let mut normalized = String::with_capacity(domain.len());
     normalized.extend(iter.nfc());
 
     let mut decoder = punycode::Decoder::default();
-    let mut validated = String::new();
     let non_transitional = config.transitional_processing(false);
     let (mut first, mut valid, mut has_bidi_labels) = (true, true, false);
     for label in normalized.split('.') {
         if !first {
-            validated.push('.');
+            output.push('.');
         }
         first = false;
         if label.starts_with(PUNYCODE_PREFIX) {
             match decoder.decode(&label[PUNYCODE_PREFIX.len()..]) {
                 Ok(decode) => {
-                    let start = validated.len();
-                    validated.extend(decode);
-                    let decoded_label = &validated[start..];
+                    let start = output.len();
+                    output.extend(decode);
+                    let decoded_label = &output[start..];
 
                     if !has_bidi_labels {
                         has_bidi_labels |= is_bidi_domain(decoded_label);
@@ -409,11 +418,11 @@ fn processing(domain: &str, config: Config, errors: &mut Vec<Error>) -> String {
 
             // `normalized` is already `NFC` so we can skip that check
             valid &= is_valid(label, config);
-            validated.push_str(label)
+            output.push_str(label)
         }
     }
 
-    for label in validated.split('.') {
+    for label in output[offset..].split('.') {
         // V8: Bidi rules
         //
         // TODO: Add *CheckBidi* flag
@@ -426,8 +435,95 @@ fn processing(domain: &str, config: Config, errors: &mut Vec<Error>) -> String {
     if !valid {
         errors.push(Error::ValidityCriteria);
     }
+}
 
-    validated
+#[derive(Default)]
+pub struct Codec {
+    config: Config,
+    normalized: String,
+    output: String,
+    errors: Vec<Error>,
+}
+
+impl Codec {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            normalized: String::new(),
+            output: String::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    /// http://www.unicode.org/reports/tr46/#ToASCII
+    pub fn to_ascii<'a>(&'a mut self, domain: &str, out: &mut String) -> Result<(), ErrorsRef<'a>> {
+        processing(
+            domain,
+            self.config,
+            &mut self.normalized,
+            &mut self.output,
+            &mut self.errors,
+        );
+
+        let mut first = true;
+        for label in self.output.split('.') {
+            if !first {
+                out.push('.');
+            }
+            first = false;
+            if label.is_ascii() {
+                out.push_str(label);
+            } else {
+                match punycode::encode_str(label) {
+                    Some(x) => {
+                        out.push_str(PUNYCODE_PREFIX);
+                        out.push_str(&x);
+                    }
+                    None => self.errors.push(Error::PunycodeError),
+                }
+            }
+        }
+
+        if self.config.verify_dns_length {
+            let domain = if out.ends_with(".") {
+                &out[..out.len() - 1]
+            } else {
+                &*out
+            };
+            if domain.len() < 1 || domain.split('.').any(|label| label.len() < 1) {
+                self.errors.push(Error::TooShortForDns)
+            }
+            if domain.len() > 253 || domain.split('.').any(|label| label.len() > 63) {
+                self.errors.push(Error::TooLongForDns)
+            }
+        }
+
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ErrorsRef(&self.errors))
+        }
+    }
+
+    /// http://www.unicode.org/reports/tr46/#ToUnicode
+    pub fn to_unicode<'a>(
+        &'a mut self,
+        domain: &str,
+        out: &mut String,
+    ) -> Result<(), ErrorsRef<'a>> {
+        processing(
+            domain,
+            self.config,
+            &mut self.normalized,
+            out,
+            &mut self.errors,
+        );
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ErrorsRef(&self.errors))
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -481,57 +577,20 @@ impl Config {
 
     /// http://www.unicode.org/reports/tr46/#ToASCII
     pub fn to_ascii(self, domain: &str) -> Result<String, Errors> {
-        let mut errors = Vec::new();
         let mut result = String::new();
-        let mut first = true;
-        for label in processing(domain, self, &mut errors).split('.') {
-            if !first {
-                result.push('.');
-            }
-            first = false;
-            if label.is_ascii() {
-                result.push_str(label);
-            } else {
-                match punycode::encode_str(label) {
-                    Some(x) => {
-                        result.push_str(PUNYCODE_PREFIX);
-                        result.push_str(&x);
-                    }
-                    None => errors.push(Error::PunycodeError),
-                }
-            }
-        }
-
-        if self.verify_dns_length {
-            let domain = if result.ends_with('.') {
-                &result[..result.len() - 1]
-            } else {
-                &*result
-            };
-            if domain.is_empty() || domain.split('.').any(|label| label.is_empty()) {
-                errors.push(Error::TooShortForDns)
-            }
-            if domain.len() > 253 || domain.split('.').any(|label| label.len() > 63) {
-                errors.push(Error::TooLongForDns)
-            }
-        }
-        if errors.is_empty() {
-            Ok(result)
-        } else {
-            Err(Errors(errors))
-        }
+        let mut codec = Codec::new(self);
+        codec
+            .to_ascii(domain, &mut result)
+            .map(|()| result)
+            .map_err(|e| e.into())
     }
 
     /// http://www.unicode.org/reports/tr46/#ToUnicode
     pub fn to_unicode(self, domain: &str) -> (String, Result<(), Errors>) {
-        let mut errors = Vec::new();
-        let domain = processing(domain, self, &mut errors);
-        let errors = if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(Errors(errors))
-        };
-        (domain, errors)
+        let mut codec = Codec::new(self);
+        let mut out = String::with_capacity(domain.len());
+        let result = codec.to_unicode(domain, &mut out);
+        (out, result.map_err(|e| e.into()))
     }
 }
 
@@ -580,6 +639,17 @@ fn is_bidi_domain(s: &str) -> bool {
     false
 }
 
+#[derive(Debug)]
+pub struct ErrorsRef<'a>(&'a [Error]);
+
+impl<'a> StdError for ErrorsRef<'a> {}
+
+impl<'a> fmt::Display for ErrorsRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 /// Errors recorded during UTS #46 processing.
 ///
 /// This is opaque for now, only indicating the presence of at least one error.
@@ -598,6 +668,12 @@ impl fmt::Display for Errors {
             f.write_str(err.as_str())?;
         }
         Ok(())
+    }
+}
+
+impl From<ErrorsRef<'_>> for Errors {
+    fn from(r: ErrorsRef<'_>) -> Errors {
+        Errors(r.0.to_owned())
     }
 }
 

--- a/idna/tests/unit.rs
+++ b/idna/tests/unit.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use unicode_normalization::char::is_combining_mark;
 
 fn _to_ascii(domain: &str) -> Result<String, idna::Errors> {
@@ -5,6 +6,54 @@ fn _to_ascii(domain: &str) -> Result<String, idna::Errors> {
         .verify_dns_length(true)
         .use_std3_ascii_rules(true)
         .to_ascii(domain)
+}
+
+// http://www.unicode.org/reports/tr46/#Table_Example_Processing
+#[test]
+fn test_examples() {
+    let mut codec = idna::Codec::default();
+    let mut out = String::new();
+
+    assert_matches!(codec.to_unicode("Bloß.de", &mut out), Ok(()));
+    assert_eq!(out, "bloß.de");
+
+    out.clear();
+    assert_matches!(
+        codec.to_unicode("xn--blo-7ka.de", &mut out),
+        Ok(())
+    );
+    assert_eq!(out, "bloß.de");
+
+    out.clear();
+    assert_matches!(codec.to_unicode("u\u{308}.com", &mut out), Ok(()));
+    assert_eq!(out, "ü.com");
+
+    out.clear();
+    assert_matches!(codec.to_unicode("xn--tda.com", &mut out), Ok(()));
+    assert_eq!(out, "ü.com");
+
+    out.clear();
+    assert_matches!(
+        codec.to_unicode("xn--u-ccb.com", &mut out),
+        Err(_)
+    );
+
+    out.clear();
+    assert_matches!(codec.to_unicode("a⒈com", &mut out), Err(_));
+
+    out.clear();
+    assert_matches!(codec.to_unicode("xn--a-ecp.ru", &mut out), Err(_));
+
+    out.clear();
+    assert_matches!(codec.to_unicode("xn--0.pt", &mut out), Err(_));
+
+    out.clear();
+    assert_matches!(codec.to_unicode("日本語。ＪＰ", &mut out), Ok(()));
+    assert_eq!(out, "日本語.jp");
+
+    out.clear();
+    assert_matches!(codec.to_unicode("☕.us", &mut out), Ok(()));
+    assert_eq!(out, "☕.us");
 }
 
 #[test]


### PR DESCRIPTION
I started looking at the performance profile of `to_unicode()` and here I am, 12 hours later:

* Updated IDNA tests to latest version
* Updated IDNA mapping table to Unicode 13.0
* Added a `Codec` API that enables some of the allocation costs over multiple `to_unicode()`/`to_ascii()` calls

I wrote some benchmarks for `to_unicode()`, before:

```
test to_unicode_ascii        ... bench:       1,117 ns/iter (+/- 27)
test to_unicode_merged_label ... bench:       4,415 ns/iter (+/- 135)
test to_unicode_puny_label   ... bench:       2,273 ns/iter (+/- 78)
```

and after:

```
test to_unicode_ascii        ... bench:          79 ns/iter (+/- 4)
test to_unicode_merged_label ... bench:       2,034 ns/iter (+/- 58)
test to_unicode_puny_label   ... bench:       1,506 ns/iter (+/- 52)
```

These changes have taken care not to change any of the existing APIs.

Additionally, I saw the old thread about asking for maintenance help. At this point I feel like I'm in a pretty good position to help out with idna maintenance (and could potentially help with the other crates as well if that's useful). Let me know if that'd be useful/how that could take shape.

I've tried to keep commits atomic and easy to review (some of them benefit from reviewing while hiding whitespace changes). Let me know if there are any questions.