### PR TITLE
url: add TryFrom<&[u8]> for Url and TryFrom tests

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2339,6 +2339,15 @@ impl<'a> TryFrom<&'a str> for Url {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for Url {
+    type Error = ParseError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+        let s = std::str::from_utf8(bytes).map_err(|_| ParseError::InvalidUtf8)?;
+        Url::parse(s)
+    }
+}
+
 /// Display the serialization of this URL.
 impl fmt::Display for Url {
     #[inline]

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -87,6 +87,7 @@ simple_enum_error! {
     InvalidIpv4Address => "invalid IPv4 address",
     InvalidIpv6Address => "invalid IPv6 address",
     InvalidDomainCharacter => "invalid domain character",
+    InvalidUtf8 => "invalid UTF-8",
     RelativeUrlWithoutBase => "relative URL without a base",
     RelativeUrlWithCannotBeABaseBase => "relative URL with a cannot-be-a-base base",
     SetHostOnCannotBeABaseUrl => "a cannot-be-a-base URL doesn’t have a host to set",

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -10,9 +10,10 @@
 
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
+use std::convert::TryFrom;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
-use url::{form_urlencoded, Host, Url};
+use url::{form_urlencoded, Host, ParseError, Url};
 
 #[test]
 fn size() {
@@ -167,6 +168,21 @@ fn path_backslash_fun() {
 #[test]
 fn from_str() {
     assert!("http://testing.com/this".parse::<Url>().is_ok());
+}
+
+#[test]
+fn try_from_str() {
+    assert!(Url::try_from("http://testing.com/this").is_ok());
+}
+
+#[test]
+fn try_from_slice() {
+    assert!(Url::try_from(&b"http://testing.com/this"[..]).is_ok());
+}
+
+#[test]
+fn try_from_slice_invalid_utf8() {
+    assert!(Url::try_from(&[0, 159, 146, 150][..]) == Err(ParseError::InvalidUtf8));
 }
 
 #[test]


### PR DESCRIPTION
Per [discussion on Matrix](https://matrix.to/#/!wurHQemAfsdBxUYHeU:mozilla.org/$MLu4rFb7uBI54AT4-UwKZSyEMXELJRM7Rqm1dpGZ6kM?via=mozilla.org&via=matrix.org).

I didn't realize when first asking that `TryFrom<&str>` is already implemented, but hasn't been released. So, I ended up just adding the impl for byte slices, an error variant for invalid UTF-8 inputs, and tests for the impls.