### PR TITLE
remove dependency on `matches` crate - `matches!` is now in Rust stable

### DIFF
--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -8,9 +8,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 autotests = false
 
-[dependencies]
-matches = "0.1"
-
 [dev-dependencies]
 rustc-test = "0.3"
 serde = {version = "1.0", features = ["derive"]}

--- a/data-url/src/lib.rs
+++ b/data-url/src/lib.rs
@@ -15,9 +15,6 @@
 //! assert!(fragment.is_none());
 //! ```
 
-#[macro_use]
-extern crate matches;
-
 macro_rules! require {
     ($condition: expr) => {
         if !$condition {

--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -11,5 +11,4 @@ edition = "2018"
 test = false
 
 [dependencies]
-matches = "0.1"
 percent-encoding = { version = "2.1.0", path = "../percent_encoding" }

--- a/form_urlencoded/src/lib.rs
+++ b/form_urlencoded/src/lib.rs
@@ -13,9 +13,6 @@
 //! Converts between a string (such as an URL’s query string)
 //! and a sequence of (name, value) pairs.
 
-#[macro_use]
-extern crate matches;
-
 use percent_encoding::{percent_decode, percent_encode_byte};
 use std::borrow::{Borrow, Cow};
 use std::str;

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = "1.0"
 [dependencies]
 unicode-bidi = "0.3"
 unicode-normalization = "0.1.5"
-matches = "0.1"
 
 [[bench]]
 name = "all"

--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -32,9 +32,6 @@
 //! > that minimizes the impact of this transition for client software,
 //! > allowing client software to access domains that are valid under either system.
 
-#[macro_use]
-extern crate matches;
-
 pub mod punycode;
 mod uts46;
 

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -555,16 +555,16 @@ mod tests {
 
     #[test]
     fn mapping_fast_path() {
-        assert_matches!(find_char('-'), &Mapping::Valid);
-        assert_matches!(find_char('.'), &Mapping::Valid);
+        assert!(matches!(find_char('-'), &Mapping::Valid));
+        assert!(matches!(find_char('.'), &Mapping::Valid));
         for c in &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] {
-            assert_matches!(find_char(*c), &Mapping::Valid);
+            assert!(matches!(find_char(*c), &Mapping::Valid));
         }
         for c in &[
             'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
             'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
         ] {
-            assert_matches!(find_char(*c), &Mapping::Valid);
+            assert!(matches!(find_char(*c), &Mapping::Valid));
         }
     }
 }

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -26,7 +26,6 @@ bencher = "0.1"
 [dependencies]
 form_urlencoded = { version = "1.0.0", path = "../form_urlencoded" }
 idna = { version = "0.2.0", path = "../idna" }
-matches = "0.1"
 percent-encoding = { version = "2.1.0", path = "../percent_encoding" }
 serde = {version = "1.0", optional = true, features = ["derive"]}
 

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -107,8 +107,6 @@ assert_eq!(css_url.as_str(), "http://servo.github.io/rust-url/main.css");
 
 #![doc(html_root_url = "https://docs.rs/url/2.1.1")]
 
-#[macro_use]
-extern crate matches;
 pub use form_urlencoded;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
`matches!` was stabilized in Rust 1.42.0: https://doc.rust-lang.org/stable/std/macro.matches.html.