### PR TITLE
url: use Display rather than Error's description in deserialize

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2471,8 +2471,10 @@ impl<'de> serde::Deserialize<'de> for Url {
             where
                 E: Error,
             {
-                Url::parse(s)
-                    .map_err(|err| Error::invalid_value(Unexpected::Str(s), &err.description()))
+                Url::parse(s).map_err(|err| {
+                    let err_s = format!("{}", err);
+                    Error::invalid_value(Unexpected::Str(s), &err_s.as_str())
+                })
             }
         }
 


### PR DESCRIPTION
I used the `serde` feature in this crate for deserializing only to find out that [this string](https://github.com/rust-lang/rust/blob/1.47.0/library/std/src/error.rs#L139) showed up in user-facing logs as part of an error path, rather than some other text describing why we could not parse a URL, which is quite weird:

> invalid value: string "a string", expected description() is deprecated; use Display

It is caused by the deprecation of the `description()` method in the `Error` trait, since 1.42.0. Unfortunately, there's no way for the method to fail in some meaningful way, so we end up with weird error reports.

This patch just uses Display on the returned error to restore the intended behaviour.