### PR TITLE
idna: optimize punycode handling, add amortized allocation API, improve error reporting

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -19,6 +19,7 @@ harness = false
 name = "unit"
 
 [dev-dependencies]
+assert_matches = "1.3"
 bencher = "0.1"
 rustc-test = "0.3"
 serde_json = "1.0"

--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -38,7 +38,7 @@ extern crate matches;
 pub mod punycode;
 mod uts46;
 
-pub use crate::uts46::{Config, Errors};
+pub use crate::uts46::{Config, Errors, Idna};
 
 /// The [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii) algorithm.
 ///

--- a/idna/src/punycode.rs
+++ b/idna/src/punycode.rs
@@ -225,7 +225,7 @@ pub fn encode(input: &[char]) -> Option<String> {
         .map(|()| buf)
 }
 
-fn encode_into<I>(input: I, output: &mut String) -> Result<(), ()>
+pub(crate) fn encode_into<I>(input: I, output: &mut String) -> Result<(), ()>
 where
     I: Iterator<Item = char> + Clone,
 {

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -326,7 +326,12 @@ fn is_valid(label: &str, config: Config) -> bool {
 
 /// http://www.unicode.org/reports/tr46/#Processing
 #[allow(clippy::manual_strip)] // introduced in 1.45, MSRV is 1.36
-fn processing(domain: &str, config: Config) -> (String, Errors) {
+fn processing(
+    domain: &str,
+    config: Config,
+    normalized: &mut String,
+    output: &mut String,
+) -> Errors {
     // Weed out the simple cases: only allow all lowercase ASCII characters and digits where none
     // of the labels start with PUNYCODE_PREFIX and labels don't start or end with hyphen.
     let (mut prev, mut simple, mut puny_prefix) = ('?', !domain.is_empty(), 0);
@@ -358,11 +363,16 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
         }
         prev = c;
     }
+
     if simple {
-        return (domain.to_owned(), Errors::default());
+        output.push_str(domain);
+        return Errors::default();
     }
 
+    normalized.clear();
     let mut errors = Errors::default();
+    let offset = output.len();
+
     let iter = Mapper {
         chars: domain.chars(),
         config,
@@ -370,24 +380,22 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
         slice: None,
     };
 
-    let mut normalized = String::with_capacity(domain.len());
     normalized.extend(iter.nfc());
 
     let mut decoder = punycode::Decoder::default();
-    let mut validated = String::new();
     let non_transitional = config.transitional_processing(false);
     let (mut first, mut valid, mut has_bidi_labels) = (true, true, false);
     for label in normalized.split('.') {
         if !first {
-            validated.push('.');
+            output.push('.');
         }
         first = false;
         if label.starts_with(PUNYCODE_PREFIX) {
             match decoder.decode(&label[PUNYCODE_PREFIX.len()..]) {
                 Ok(decode) => {
-                    let start = validated.len();
-                    validated.extend(decode);
-                    let decoded_label = &validated[start..];
+                    let start = output.len();
+                    output.extend(decode);
+                    let decoded_label = &output[start..];
 
                     if !has_bidi_labels {
                         has_bidi_labels |= is_bidi_domain(decoded_label);
@@ -411,11 +419,11 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
 
             // `normalized` is already `NFC` so we can skip that check
             valid &= is_valid(label, config);
-            validated.push_str(label)
+            output.push_str(label)
         }
     }
 
-    for label in validated.split('.') {
+    for label in output[offset..].split('.') {
         // V8: Bidi rules
         //
         // TODO: Add *CheckBidi* flag
@@ -429,7 +437,71 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
         errors.validity_criteria = true;
     }
 
-    (validated, errors)
+    errors
+}
+
+#[derive(Default)]
+pub struct Idna {
+    config: Config,
+    normalized: String,
+    output: String,
+}
+
+impl Idna {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            normalized: String::new(),
+            output: String::new(),
+        }
+    }
+
+    /// http://www.unicode.org/reports/tr46/#ToASCII
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_ascii<'a>(&'a mut self, domain: &str, out: &mut String) -> Result<(), Errors> {
+        let mut errors = processing(domain, self.config, &mut self.normalized, &mut self.output);
+
+        let mut first = true;
+        for label in self.output.split('.') {
+            if !first {
+                out.push('.');
+            }
+            first = false;
+
+            if label.is_ascii() {
+                out.push_str(label);
+            } else {
+                let offset = out.len();
+                out.push_str(PUNYCODE_PREFIX);
+                if let Err(()) = punycode::encode_into(label.chars(), out) {
+                    errors.punycode = true;
+                    out.truncate(offset);
+                }
+            }
+        }
+
+        if self.config.verify_dns_length {
+            let domain = if out.ends_with('.') {
+                &out[..out.len() - 1]
+            } else {
+                &*out
+            };
+            if domain.is_empty() || domain.split('.').any(|label| label.is_empty()) {
+                errors.too_short_for_dns = true;
+            }
+            if domain.len() > 253 || domain.split('.').any(|label| label.len() > 63) {
+                errors.too_long_for_dns = true;
+            }
+        }
+
+        errors.into()
+    }
+
+    /// http://www.unicode.org/reports/tr46/#ToUnicode
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_unicode<'a>(&'a mut self, domain: &str, out: &mut String) -> Result<(), Errors> {
+        processing(domain, self.config, &mut self.normalized, out).into()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -484,49 +556,16 @@ impl Config {
     /// http://www.unicode.org/reports/tr46/#ToASCII
     pub fn to_ascii(self, domain: &str) -> Result<String, Errors> {
         let mut result = String::new();
-        let mut first = true;
-        let (domain, mut errors) = processing(domain, self);
-        for label in domain.split('.') {
-            if !first {
-                result.push('.');
-            }
-            first = false;
-            if label.is_ascii() {
-                result.push_str(label);
-            } else {
-                match punycode::encode_str(label) {
-                    Some(x) => {
-                        result.push_str(PUNYCODE_PREFIX);
-                        result.push_str(&x);
-                    }
-                    None => {
-                        errors.punycode = true;
-                    }
-                }
-            }
-        }
-
-        if self.verify_dns_length {
-            let domain = if result.ends_with('.') {
-                &result[..result.len() - 1]
-            } else {
-                &*result
-            };
-            if domain.is_empty() || domain.split('.').any(|label| label.is_empty()) {
-                errors.too_short_for_dns = true;
-            }
-            if domain.len() > 253 || domain.split('.').any(|label| label.len() > 63) {
-                errors.too_long_for_dns = true;
-            }
-        }
-
-        Result::from(errors).map(|()| result)
+        let mut codec = Idna::new(self);
+        codec.to_ascii(domain, &mut result).map(|()| result)
     }
 
     /// http://www.unicode.org/reports/tr46/#ToUnicode
     pub fn to_unicode(self, domain: &str) -> (String, Result<(), Errors>) {
-        let (domain, errors) = processing(domain, self);
-        (domain, errors.into())
+        let mut codec = Idna::new(self);
+        let mut out = String::with_capacity(domain.len());
+        let result = codec.to_unicode(domain, &mut out);
+        (out, result)
     }
 }
 

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -373,6 +373,7 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
     let mut normalized = String::with_capacity(domain.len());
     normalized.extend(iter.nfc());
 
+    let mut decoder = punycode::Decoder::default();
     let mut validated = String::new();
     let non_transitional = config.transitional_processing(false);
     let (mut first, mut valid, mut has_bidi_labels) = (true, true, false);
@@ -382,20 +383,23 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
         }
         first = false;
         if label.starts_with(PUNYCODE_PREFIX) {
-            match punycode::decode_to_string(&label[PUNYCODE_PREFIX.len()..]) {
-                Some(decoded_label) => {
+            match decoder.decode(&label[PUNYCODE_PREFIX.len()..]) {
+                Ok(decode) => {
+                    let start = validated.len();
+                    validated.extend(decode);
+                    let decoded_label = &validated[start..];
+
                     if !has_bidi_labels {
-                        has_bidi_labels |= is_bidi_domain(&decoded_label);
+                        has_bidi_labels |= is_bidi_domain(decoded_label);
                     }
 
                     if valid
-                        && (!is_nfc(&decoded_label) || !is_valid(&decoded_label, non_transitional))
+                        && (!is_nfc(&decoded_label) || !is_valid(decoded_label, non_transitional))
                     {
                         valid = false;
                     }
-                    validated.push_str(&decoded_label)
                 }
-                None => {
+                Err(()) => {
                     has_bidi_labels = true;
                     errors.punycode = true;
                 }

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -598,16 +598,30 @@ pub struct Errors {
     too_short_for_dns: bool,
 }
 
+impl Errors {
+    fn is_err(&self) -> bool {
+        let Errors {
+            punycode,
+            validity_criteria,
+            disallowed_by_std3_ascii_rules,
+            disallowed_mapped_in_std3,
+            disallowed_character,
+            too_long_for_dns,
+            too_short_for_dns,
+        } = *self;
+        punycode
+            || validity_criteria
+            || disallowed_by_std3_ascii_rules
+            || disallowed_mapped_in_std3
+            || disallowed_character
+            || too_long_for_dns
+            || too_short_for_dns
+    }
+}
+
 impl From<Errors> for Result<(), Errors> {
     fn from(e: Errors) -> Result<(), Errors> {
-        let failed = e.punycode
-            || e.validity_criteria
-            || e.disallowed_by_std3_ascii_rules
-            || e.disallowed_mapped_in_std3
-            || e.disallowed_character
-            || e.too_long_for_dns
-            || e.too_short_for_dns;
-        if !failed {
+        if !e.is_err() {
             Ok(())
         } else {
             Err(e)

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -586,7 +586,7 @@ fn is_bidi_domain(s: &str) -> bool {
 ///
 /// This is opaque for now, indicating what types of errors have been encountered at least once.
 /// More details may be exposed in the future.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Errors {
     punycode: bool,
     // https://unicode.org/reports/tr46/#Validity_Criteria
@@ -616,6 +616,48 @@ impl Errors {
             || disallowed_character
             || too_long_for_dns
             || too_short_for_dns
+    }
+}
+
+impl fmt::Debug for Errors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Errors {
+            punycode,
+            validity_criteria,
+            disallowed_by_std3_ascii_rules,
+            disallowed_mapped_in_std3,
+            disallowed_character,
+            too_long_for_dns,
+            too_short_for_dns,
+        } = *self;
+
+        let fields = [
+            ("punycode", punycode),
+            ("validity_criteria", validity_criteria),
+            ("disallowed_by_std3_ascii_rules", disallowed_by_std3_ascii_rules),
+            ("disallowed_mapped_in_std3", disallowed_mapped_in_std3),
+            ("disallowed_character", disallowed_character),
+            ("too_long_for_dns", too_long_for_dns),
+            ("too_short_for_dns", too_short_for_dns),
+        ];
+
+        let mut empty = true;
+        f.write_str("Errors { ")?;
+        for (name, val) in &fields {
+            if *val {
+                if !empty {
+                    f.write_str(", ")?;
+                }
+                f.write_str(*name)?;
+                empty = false;
+            }
+        }
+
+        if !empty {
+            f.write_str(" }")
+        } else {
+            f.write_str("}")
+        }
     }
 }
 

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -82,38 +82,65 @@ fn find_char(codepoint: char) -> &'static Mapping {
         .unwrap()
 }
 
-fn map_char(codepoint: char, config: Config, output: &mut String, errors: &mut Errors) {
-    if let '.' | '-' | 'a'..='z' | '0'..='9' = codepoint {
-        output.push(codepoint);
-        return;
-    }
+struct Mapper<'a> {
+    chars: std::str::Chars<'a>,
+    config: Config,
+    errors: &'a mut Errors,
+    slice: Option<std::str::Chars<'static>>,
+}
 
-    match *find_char(codepoint) {
-        Mapping::Valid => output.push(codepoint),
-        Mapping::Ignored => {}
-        Mapping::Mapped(ref slice) => output.push_str(decode_slice(slice)),
-        Mapping::Deviation(ref slice) => {
-            if config.transitional_processing {
-                output.push_str(decode_slice(slice))
-            } else {
-                output.push(codepoint)
+impl<'a> Iterator for Mapper<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(s) = &mut self.slice {
+                match s.next() {
+                    Some(c) => return Some(c),
+                    None => {
+                        self.slice = None;
+                    }
+                }
             }
-        }
-        Mapping::Disallowed => {
-            errors.disallowed_character = true;
-            output.push(codepoint);
-        }
-        Mapping::DisallowedStd3Valid => {
-            if config.use_std3_ascii_rules {
-                errors.disallowed_by_std3_ascii_rules = true;
+
+            let codepoint = self.chars.next()?;
+            if let '.' | '-' | 'a'..='z' | '0'..='9' = codepoint {
+                return Some(codepoint);
             }
-            output.push(codepoint)
-        }
-        Mapping::DisallowedStd3Mapped(ref slice) => {
-            if config.use_std3_ascii_rules {
-                errors.disallowed_mapped_in_std3 = true;
-            }
-            output.push_str(decode_slice(slice))
+
+            return Some(match *find_char(codepoint) {
+                Mapping::Valid => codepoint,
+                Mapping::Ignored => continue,
+                Mapping::Mapped(ref slice) => {
+                    self.slice = Some(decode_slice(slice).chars());
+                    continue;
+                }
+                Mapping::Deviation(ref slice) => {
+                    if self.config.transitional_processing {
+                        self.slice = Some(decode_slice(slice).chars());
+                        continue;
+                    } else {
+                        codepoint
+                    }
+                }
+                Mapping::Disallowed => {
+                    self.errors.disallowed_character = true;
+                    codepoint
+                }
+                Mapping::DisallowedStd3Valid => {
+                    if self.config.use_std3_ascii_rules {
+                        self.errors.disallowed_by_std3_ascii_rules = true;
+                    };
+                    codepoint
+                }
+                Mapping::DisallowedStd3Mapped(ref slice) => {
+                    if self.config.use_std3_ascii_rules {
+                        self.errors.disallowed_mapped_in_std3 = true;
+                    };
+                    self.slice = Some(decode_slice(slice).chars());
+                    continue;
+                }
+            });
         }
     }
 }
@@ -336,12 +363,15 @@ fn processing(domain: &str, config: Config) -> (String, Errors) {
     }
 
     let mut errors = Errors::default();
-    let mut mapped = String::with_capacity(domain.len());
-    for c in domain.chars() {
-        map_char(c, config, &mut mapped, &mut errors)
-    }
-    let mut normalized = String::with_capacity(mapped.len());
-    normalized.extend(mapped.nfc());
+    let iter = Mapper {
+        chars: domain.chars(),
+        config,
+        errors: &mut errors,
+        slice: None,
+    };
+
+    let mut normalized = String::with_capacity(domain.len());
+    normalized.extend(iter.nfc());
 
     let mut validated = String::new();
     let non_transitional = config.transitional_processing(false);

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -279,11 +279,11 @@ fn passes_bidi(label: &str, is_bidi_domain: bool) -> bool {
 /// V1 (NFC) and V8 (Bidi) are checked inside `processing()` to prevent doing duplicate work.
 ///
 /// http://www.unicode.org/reports/tr46/#Validity_Criteria
-fn is_valid(label: &str, config: Config) -> bool {
+fn check_validity(label: &str, config: Config, errors: &mut Errors) {
     let first_char = label.chars().next();
     if first_char == None {
         // Empty string, pass
-        return true;
+        return;
     }
 
     // V2: No U+002D HYPHEN-MINUS in both third and fourth positions.
@@ -294,7 +294,8 @@ fn is_valid(label: &str, config: Config) -> bool {
 
     // V3: neither begin nor end with a U+002D HYPHEN-MINUS
     if config.check_hyphens && (label.starts_with('-') || label.ends_with('-')) {
-        return false;
+        errors.check_hyphens = true;
+        return;
     }
 
     // V4: not contain a U+002E FULL STOP
@@ -303,7 +304,8 @@ fn is_valid(label: &str, config: Config) -> bool {
 
     // V5: not begin with a GC=Mark
     if is_combining_mark(first_char.unwrap()) {
-        return false;
+        errors.start_combining_mark = true;
+        return;
     }
 
     // V6: Check against Mapping Table
@@ -313,7 +315,8 @@ fn is_valid(label: &str, config: Config) -> bool {
         Mapping::DisallowedStd3Valid => config.use_std3_ascii_rules,
         _ => true,
     }) {
-        return false;
+        errors.invalid_mapping = true;
+        return;
     }
 
     // V7: ContextJ rules
@@ -321,7 +324,6 @@ fn is_valid(label: &str, config: Config) -> bool {
     // TODO: Implement rules and add *CheckJoiners* flag.
 
     // V8: Bidi rules are checked inside `processing()`
-    true
 }
 
 /// http://www.unicode.org/reports/tr46/#Processing
@@ -384,7 +386,7 @@ fn processing(
 
     let mut decoder = punycode::Decoder::default();
     let non_transitional = config.transitional_processing(false);
-    let (mut first, mut valid, mut has_bidi_labels) = (true, true, false);
+    let (mut first, mut has_bidi_labels) = (true, false);
     for label in normalized.split('.') {
         if !first {
             output.push('.');
@@ -401,10 +403,12 @@ fn processing(
                         has_bidi_labels |= is_bidi_domain(decoded_label);
                     }
 
-                    if valid
-                        && (!is_nfc(&decoded_label) || !is_valid(decoded_label, non_transitional))
-                    {
-                        valid = false;
+                    if !errors.is_err() {
+                        if !is_nfc(&decoded_label) {
+                            errors.nfc = true;
+                        } else {
+                            check_validity(decoded_label, non_transitional, &mut errors);
+                        }
                     }
                 }
                 Err(()) => {
@@ -418,7 +422,7 @@ fn processing(
             }
 
             // `normalized` is already `NFC` so we can skip that check
-            valid &= is_valid(label, config);
+            check_validity(label, config, &mut errors);
             output.push_str(label)
         }
     }
@@ -428,13 +432,9 @@ fn processing(
         //
         // TODO: Add *CheckBidi* flag
         if !passes_bidi(label, has_bidi_labels) {
-            valid = false;
+            errors.check_bidi = true;
             break;
         }
-    }
-
-    if !valid {
-        errors.validity_criteria = true;
     }
 
     errors
@@ -589,8 +589,11 @@ fn is_bidi_domain(s: &str) -> bool {
 #[derive(Default)]
 pub struct Errors {
     punycode: bool,
-    // https://unicode.org/reports/tr46/#Validity_Criteria
-    validity_criteria: bool,
+    check_hyphens: bool,
+    check_bidi: bool,
+    start_combining_mark: bool,
+    invalid_mapping: bool,
+    nfc: bool,
     disallowed_by_std3_ascii_rules: bool,
     disallowed_mapped_in_std3: bool,
     disallowed_character: bool,
@@ -602,7 +605,11 @@ impl Errors {
     fn is_err(&self) -> bool {
         let Errors {
             punycode,
-            validity_criteria,
+            check_hyphens,
+            check_bidi,
+            start_combining_mark,
+            invalid_mapping,
+            nfc,
             disallowed_by_std3_ascii_rules,
             disallowed_mapped_in_std3,
             disallowed_character,
@@ -610,7 +617,11 @@ impl Errors {
             too_short_for_dns,
         } = *self;
         punycode
-            || validity_criteria
+            || check_hyphens
+            || check_bidi
+            || start_combining_mark
+            || invalid_mapping
+            || nfc
             || disallowed_by_std3_ascii_rules
             || disallowed_mapped_in_std3
             || disallowed_character
@@ -623,7 +634,11 @@ impl fmt::Debug for Errors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Errors {
             punycode,
-            validity_criteria,
+            check_hyphens,
+            check_bidi,
+            start_combining_mark,
+            invalid_mapping,
+            nfc,
             disallowed_by_std3_ascii_rules,
             disallowed_mapped_in_std3,
             disallowed_character,
@@ -633,8 +648,15 @@ impl fmt::Debug for Errors {
 
         let fields = [
             ("punycode", punycode),
-            ("validity_criteria", validity_criteria),
-            ("disallowed_by_std3_ascii_rules", disallowed_by_std3_ascii_rules),
+            ("check_hyphens", check_hyphens),
+            ("check_bidi", check_bidi),
+            ("start_combining_mark", start_combining_mark),
+            ("invalid_mapping", invalid_mapping),
+            ("nfc", nfc),
+            (
+                "disallowed_by_std3_ascii_rules",
+                disallowed_by_std3_ascii_rules,
+            ),
             ("disallowed_mapped_in_std3", disallowed_mapped_in_std3),
             ("disallowed_character", disallowed_character),
             ("too_long_for_dns", too_long_for_dns),


### PR DESCRIPTION
Benchmarks before:

```
test to_ascii_merged         ... bench:       2,102 ns/iter (+/- 309)
test to_ascii_puny_label     ... bench:       1,214 ns/iter (+/- 220)
test to_ascii_simple         ... bench:         246 ns/iter (+/- 34)
test to_unicode_ascii        ... bench:          74 ns/iter (+/- 14)
test to_unicode_merged_label ... bench:       2,127 ns/iter (+/- 400)
test to_unicode_puny_label   ... bench:       1,328 ns/iter (+/- 353)
```

Benchmarks after:

```
test to_ascii_merged         ... bench:       1,937 ns/iter (+/- 497)
test to_ascii_puny_label     ... bench:       1,147 ns/iter (+/- 254)
test to_ascii_simple         ... bench:         247 ns/iter (+/- 74)
test to_unicode_ascii        ... bench:          78 ns/iter (+/- 14)
test to_unicode_merged_label ... bench:       1,848 ns/iter (+/- 239)
test to_unicode_puny_label   ... bench:       1,158 ns/iter (+/- 312)
```

Across a few runs, I see performance improvements like this:

to_ascii_merged: 4%
to_ascii_puny_label: 12%
to_ascii_simple: 3%
to_unicode_ascii: -5% (but on a much smaller base)
to_unicode_merged_label: 14%
to_unicode_puny_label: 13%

This pretty much comes from the first four commits (each commit is logically separate and can be reviewed as such, although some of the first commits don't pay off in performance until the fourth one). The fifth commit adds a separate API that allows reusing allocations -- any performance benefits of this aren't reflected in the benchmarks because they only do one operation per benchmark. The final three commits instead improve error handling (although they don't change the API).

All of this comes at the cost of +300 SLOC in the idna crate.

I'm using this for my work project, so would like to get something like this merged.