### PR TITLE
Include username and password in Url's Debug implementation

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2374,6 +2374,8 @@ impl fmt::Debug for Url {
             .field("path", &self.path())
             .field("query", &self.query())
             .field("fragment", &self.fragment())
+            .field("username", &self.username())
+            .field("password", &self.password())
             .finish()
     }
 }

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2369,13 +2369,13 @@ impl fmt::Debug for Url {
         formatter
             .debug_struct("Url")
             .field("scheme", &self.scheme())
+            .field("username", &self.username())
+            .field("password", &self.password())
             .field("host", &self.host())
             .field("port", &self.port())
             .field("path", &self.path())
             .field("query", &self.query())
             .field("fragment", &self.fragment())
-            .field("username", &self.username())
-            .field("password", &self.password())
             .finish()
     }
 }


### PR DESCRIPTION
While looking into improving fuzzing I noticed that these two fields are missing which can make it confusing when two urls aren't equal but their debug is equal.