### PR TITLE
small documentation inaccuracy

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -842,7 +842,8 @@ impl Url {
     }
 
     /// Return the parsed representation of the host for this URL.
-    /// Non-ASCII domain labels are punycode-encoded per IDNA.
+    /// Non-ASCII domain labels are punycode-encoded per IDNA if this is the host
+    /// of a special URL, or percent encoded for non-special URLs.
     ///
     /// Cannot-be-a-base URLs (typical of `data:` and `mailto:`) and some `file:` URLs
     /// don’t have a host.

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -803,7 +803,8 @@ impl Url {
 
     /// Return the string representation of the host (domain or IP address) for this URL, if any.
     ///
-    /// Non-ASCII domains are punycode-encoded per IDNA.
+    /// Non-ASCII domains are punycode-encoded per IDNA if this is the host
+    /// of a special URL, or percent encoded for non-special URLs.
     /// IPv6 addresses are given between `[` and `]` brackets.
     ///
     /// Cannot-be-a-base URLs (typical of `data:` and `mailto:`) and some `file:` URLs
@@ -882,6 +883,8 @@ impl Url {
     }
 
     /// If this URL has a host and it is a domain name (not an IP address), return it.
+    /// Non-ASCII domains are punycode-encoded per IDNA if this is the host
+    /// of a special URL, or percent encoded for non-special URLs.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Fixed a small inaccuracy in the docs for [`url::Url::host`](https://docs.rs/url/2.2.0/url/struct.Url.html#method.host). It did only say that domains would be IDNA encoded when in fact as documented at [`url::Host::Domain`](https://docs.rs/url/2.2.0/url/enum.Host.html#variant.Domain), for URLs with a "non-special" scheme, domains will be percent encoded.