### PR TITLE
Use assert!()'s built-in formatting mechanics

### DIFF
--- a/idna/tests/punycode.rs
+++ b/idna/tests/punycode.rs
@@ -19,10 +19,10 @@ fn one_test(decoded: &str, encoded: &str) {
             let result = result.into_iter().collect::<String>();
             assert!(
                 result == decoded,
-                format!(
-                    "Incorrect decoding of \"{}\":\n   \"{}\"\n!= \"{}\"\n",
-                    encoded, result, decoded
-                )
+                "Incorrect decoding of \"{}\":\n   \"{}\"\n!= \"{}\"\n",
+                encoded,
+                result,
+                decoded
             )
         }
     }
@@ -31,10 +31,10 @@ fn one_test(decoded: &str, encoded: &str) {
         None => panic!("Encoding {} failed.", decoded),
         Some(result) => assert!(
             result == encoded,
-            format!(
-                "Incorrect encoding of \"{}\":\n   \"{}\"\n!= \"{}\"\n",
-                decoded, result, encoded
-            )
+            "Incorrect encoding of \"{}\":\n   \"{}\"\n!= \"{}\"\n",
+            decoded,
+            result,
+            encoded
         ),
     }
 }


### PR DESCRIPTION
As suggested by clippy. Apparently this becomes a hard error in the 2021 edition.