### PR TITLE
Update to 1.0.1

### DIFF
--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The rust-url developers"]
 description = "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms."
 repository = "https://github.com/servo/rust-url"


### PR DESCRIPTION
Include commits made since the update to 1.0.0 such as:
https://github.com/servo/rust-url/commit/47b6555

Which is needed for building the tests now included in:
https://github.com/servo/rust-url/pull/683/commits/5d0ee3a