### PR TITLE
Use collections from the alloc crate in percent_encoding

### DIFF
--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -6,6 +6,3 @@ description = "Percent encoding and decoding"
 repository = "https://github.com/servo/rust-url/"
 license = "MIT/Apache-2.0"
 edition = "2018"
-
-[dependencies]
-beef = { version = "0.5", optional = true }

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -7,6 +7,5 @@ repository = "https://github.com/servo/rust-url/"
 license = "MIT/Apache-2.0"
 edition = "2018"
 
-[features]
-default = ["std"]
-std = []
+[dependencies]
+beef = { version = "0.5", optional = true }

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -6,3 +6,7 @@ description = "Percent encoding and decoding"
 repository = "https://github.com/servo/rust-url/"
 license = "MIT/Apache-2.0"
 edition = "2018"
+
+[features]
+default = ["alloc"]
+alloc = []

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -38,14 +38,16 @@
 //! ```
 
 #![no_std]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
+use core::{fmt, mem, slice, str};
+#[cfg(feature = "alloc")]
 use alloc::{
     borrow::{Cow, ToOwned},
     string::String,
     vec::Vec,
 };
-use core::{fmt, mem, slice, str};
 
 /// Represents a set of characters or bytes in the ASCII range.
 ///
@@ -294,6 +296,7 @@ impl<'a> fmt::Display for PercentEncode<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<PercentEncode<'a>> for Cow<'a, str> {
     fn from(mut iter: PercentEncode<'a>) -> Self {
         match iter.next() {
@@ -379,6 +382,7 @@ impl<'a> Iterator for PercentDecode<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<PercentDecode<'a>> for Cow<'a, [u8]> {
     fn from(iter: PercentDecode<'a>) -> Self {
         match iter.if_any() {
@@ -390,6 +394,7 @@ impl<'a> From<PercentDecode<'a>> for Cow<'a, [u8]> {
 
 impl<'a> PercentDecode<'a> {
     /// If the percent-decoding is different from the input, return it as a new bytes vector.
+    #[cfg(feature = "alloc")]
     fn if_any(&self) -> Option<Vec<u8>> {
         let mut bytes_iter = self.bytes.clone();
         while bytes_iter.any(|&b| b == b'%') {
@@ -409,6 +414,7 @@ impl<'a> PercentDecode<'a> {
     /// Decode the result of percent-decoding as UTF-8.
     ///
     /// This is return `Err` when the percent-decoded bytes are not well-formed in UTF-8.
+    #[cfg(feature = "alloc")]
     pub fn decode_utf8(self) -> Result<Cow<'a, str>, str::Utf8Error> {
         match self.clone().into() {
             Cow::Borrowed(bytes) => match str::from_utf8(bytes) {
@@ -426,11 +432,13 @@ impl<'a> PercentDecode<'a> {
     ///
     /// Invalid UTF-8 percent-encoded byte sequences will be replaced � U+FFFD,
     /// the replacement character.
+    #[cfg(feature = "alloc")]
     pub fn decode_utf8_lossy(self) -> Cow<'a, str> {
         decode_utf8_lossy(self.clone().into())
     }
 }
 
+#[cfg(feature = "alloc")]
 fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     // Note: This function is duplicated in `form_urlencoded/src/query_encoding.rs`.
     match input {

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -40,7 +40,11 @@
 #![no_std]
 extern crate alloc;
 
-use alloc::{borrow::{Cow, ToOwned}, vec::Vec, string::String};
+use alloc::{
+    borrow::{Cow, ToOwned},
+    string::String,
+    vec::Vec,
+};
 use core::{fmt, mem, slice, str};
 
 /// Represents a set of characters or bytes in the ASCII range.
@@ -307,42 +311,6 @@ impl<'a> From<PercentEncode<'a>> for Cow<'a, str> {
     }
 }
 
-#[cfg(feature = "beef")]
-impl<'a> From<PercentEncode<'a>> for beef::Cow<'a, str> {
-    fn from(mut iter: PercentEncode<'a>) -> Self {
-        match iter.next() {
-            None => "".into(),
-            Some(first) => match iter.next() {
-                None => first.into(),
-                Some(second) => {
-                    let mut string = first.to_owned();
-                    string.push_str(second);
-                    string.extend(iter);
-                    string.into()
-                }
-            },
-        }
-    }
-}
-
-#[cfg(all(feature = "beef", target_pointer_width = "64"))]
-impl<'a> From<PercentEncode<'a>> for beef::lean::Cow<'a, str> {
-    fn from(mut iter: PercentEncode<'a>) -> Self {
-        match iter.next() {
-            None => "".into(),
-            Some(first) => match iter.next() {
-                None => first.into(),
-                Some(second) => {
-                    let mut string = first.to_owned();
-                    string.push_str(second);
-                    string.extend(iter);
-                    string.into()
-                }
-            },
-        }
-    }
-}
-
 /// Percent-decode the given string.
 ///
 /// <https://url.spec.whatwg.org/#string-percent-decode>
@@ -416,26 +384,6 @@ impl<'a> From<PercentDecode<'a>> for Cow<'a, [u8]> {
         match iter.if_any() {
             Some(vec) => Cow::Owned(vec),
             None => Cow::Borrowed(iter.bytes.as_slice()),
-        }
-    }
-}
-
-#[cfg(feature = "beef")]
-impl<'a> From<PercentDecode<'a>> for beef::Cow<'a, [u8]> {
-    fn from(iter: PercentDecode<'a>) -> Self {
-        match iter.if_any() {
-            Some(vec) => beef::Cow::owned(vec),
-            None => beef::Cow::borrowed(iter.bytes.as_slice()),
-        }
-    }
-}
-
-#[cfg(all(feature = "beef", target_pointer_width = "64"))]
-impl<'a> From<PercentDecode<'a>> for beef::lean::Cow<'a, [u8]> {
-    fn from(iter: PercentDecode<'a>) -> Self {
-        match iter.if_any() {
-            Some(vec) => beef::lean::Cow::owned(vec),
-            None => beef::lean::Cow::borrowed(iter.bytes.as_slice()),
         }
     }
 }

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -41,13 +41,13 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-use core::{fmt, mem, slice, str};
 #[cfg(feature = "alloc")]
 use alloc::{
     borrow::{Cow, ToOwned},
     string::String,
     vec::Vec,
 };
+use core::{fmt, mem, slice, str};
 
 /// Represents a set of characters or bytes in the ASCII range.
 ///


### PR DESCRIPTION
Use collections from `alloc` in the `percent_encoding` crate, thus making it fully `no_std` compatible.

~~Additionally implements `From<PercendEncode>>` and `From<PercendDecode>>` for `beef::Cow`, using an optional `beef` feature gate.~~
Edit: ditched the beef implementation as it didn't pass all of the checks.