### PR TITLE
fix: implement std::error::Error for data-url

### DIFF
--- a/data-url/src/lib.rs
+++ b/data-url/src/lib.rs
@@ -18,7 +18,7 @@
 
 // For forwards compatibility
 #[cfg(feature = "std")]
-extern crate std as _;
+extern crate std;
 
 #[macro_use]
 extern crate alloc;
@@ -27,6 +27,7 @@ extern crate alloc;
 compile_error!("the `alloc` feature must be enabled");
 
 use alloc::{string::String, vec::Vec};
+use core::fmt;
 
 macro_rules! require {
     ($condition: expr) => {
@@ -50,6 +51,21 @@ pub enum DataUrlError {
     NotADataUrl,
     NoComma,
 }
+
+impl fmt::Display for DataUrlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotADataUrl => write!(f, "not a valid data url"),
+            Self::NoComma => write!(
+                f,
+                "data url is missing comma delimiting attributes and body"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DataUrlError {}
 
 impl<'a> DataUrl<'a> {
     /// <https://fetch.spec.whatwg.org/#data-url-processor>

--- a/data-url/src/mime.rs
+++ b/data-url/src/mime.rs
@@ -26,6 +26,15 @@ impl Mime {
 #[derive(Debug)]
 pub struct MimeParsingError(());
 
+impl fmt::Display for MimeParsingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid mime type")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MimeParsingError {}
+
 /// <https://mimesniff.spec.whatwg.org/#parsing-a-mime-type>
 impl FromStr for Mime {
     type Err = MimeParsingError;


### PR DESCRIPTION
This commit implements std::error::Error for errors in the `data-url`
crate.

Closes #697
