### PR TITLE
`Url::port_int` implementation

### DIFF
--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -128,7 +128,7 @@ pub fn set_host(url: &mut Url, new_host: &str) -> Result<(), ()> {
                 } else {
                     Parser::parse_port(remaining, || default_port(scheme), Context::Setter)
                         .ok()
-                        .map(|(port, _remaining)| port)
+                        .map(|(port, port_int, _remaining)| (port, port_int))
                 }
             } else {
                 None
@@ -141,7 +141,7 @@ pub fn set_host(url: &mut Url, new_host: &str) -> Result<(), ()> {
     if host == Host::Domain("".to_string()) {
         if !username(&url).is_empty() {
             return Err(());
-        } else if let Some(Some(_)) = opt_port {
+        } else if let Some((_, Some(_))) = opt_port {
             return Err(());
         } else if url.port().is_some() {
             return Err(());
@@ -215,8 +215,8 @@ pub fn set_port(url: &mut Url, new_port: &str) -> Result<(), ()> {
             Context::Setter,
         )
     }
-    if let Ok((new_port, _remaining)) = result {
-        url.set_port_internal(new_port);
+    if let Ok((new_port, new_port_int, _remaining)) = result {
+        url.set_port_internal(new_port, new_port_int);
         Ok(())
     } else {
         Err(())

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -845,3 +845,26 @@ fn pop_if_empty_in_bounds() {
     segments.pop_if_empty();
     segments.pop();
 }
+
+#[test]
+fn port_int() {
+    let url = Url::parse("http://example.net:80").unwrap();
+    assert_eq!(url.port(), None);
+    assert_eq!(url.port_or_known_default(), Some(80));
+    assert_eq!(url.port_int(), Some(80));
+
+    let url = Url::parse("http://example.net").unwrap();
+    assert_eq!(url.port(), None);
+    assert_eq!(url.port_or_known_default(), Some(80));
+    assert_eq!(url.port_int(), None);
+
+    let url = Url::parse("custom-protocol://example.net").unwrap();
+    assert_eq!(url.port(), None);
+    assert_eq!(url.port_or_known_default(), None);
+    assert_eq!(url.port_int(), None);
+
+    let url = Url::parse("custom-protocol://example.net:8000").unwrap();
+    assert_eq!(url.port(), Some(8000));
+    assert_eq!(url.port_or_known_default(), Some(8000));
+    assert_eq!(url.port_int(), Some(8000));
+}


### PR DESCRIPTION
Some questions arose up while I was doing this implementation.

- I implemented this by adding a field `port_int` to `Url`, my initial implementation actually handled it by storing the actual port always in `Url::port` and when using the method `Url::port()` it would filter based on scheme defaults. In addition the `Url::serialization` would always contain the correctly removed default port. This implementation caused a lot of edge cases to arise, so I avoided it by doing it in a separate field.
- Currently when changing a scheme with `Url::set_scheme`, `Url::port_int` is removed if it was the scheme default, see #61. Probably it would be more intuitive that if `Url::port_int` is empty, ergo the user didn't define a port (default or not), then having the new port be the default port for that scheme makes sense. But if the user deliberately defined the default port on the URL, changing the scheme shouldn't change the port.
  ```rust
  // this makes sense
  let mut url = Url::parse("http://example.net").unwrap();
  url.set_scheme("https").unwrap();
  assert_eq!(url.port(), None);
  assert_eq!(url.port_int(), None);
  assert_eq!(url.port_or_known_default(), Some(443));
  
  // this is not intuitive
  let mut url = Url::parse("http://example.net:80").unwrap();
  assert_eq!(url.port(), None);
  assert_eq!(url.port_int(), Some(80));
  assert_eq!(url.port_or_known_default(), Some(80));
  url.set_scheme("https").unwrap();
  assert_eq!(url.port(), None);
  assert_eq!(url.port_int(), None); // why does this vanish, probably expected to stay 80
  assert_eq!(url.port_or_known_default(), Some(443)); // probably expected to stay 80
  
  // even weirder, but you shouldn't use a assigned port to a custom protocol anyway
  let mut url = Url::parse("custom-protocol://example.net:80").unwrap();
  assert_eq!(url.port(), Some(80));
  assert_eq!(url.port_int(), Some(80));
  assert_eq!(url.port_or_known_default(), Some(80));
  url.set_scheme("http").unwrap();
  assert_eq!(url.port(), None);
  assert_eq!(url.port_int(), None);
  assert_eq!(url.port_or_known_default(), Some(80));
  url.set_scheme("https").unwrap();
  assert_eq!(url.port(), None);
  assert_eq!(url.port_int(), None);
  assert_eq!(url.port_or_known_default(), Some(443)); // port changed completely, I guess this is potentially an issue with the current implementation too
  ```
  I don't think this is a big deal, I would argue that this is a pretty bad use-case the url crate might not want to support.
- Comparing two `Url`s with different `Url::port_int` might turn out to be equal, because it compares `Url::serialization`, and default ports for scheme aren't reflected in the serialization.

---

Personally I'm fine with last two points, I consider them edge-cases that are fine for the url crate to ignore.

Fixes #706.