### PR TITLE
Add tests for SyntaxViolation callback types

### DIFF
--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -795,7 +795,7 @@ fn test_syntax_violation_callback_types() {
         ("http:///mozilla.org", ExpectedDoubleSlash, "expected //"),
         ("file:/foo.txt", ExpectedFileDoubleSlash, "expected // after file:"),
         ("file://mozilla.org/c:/file.txt", FileWithHostAndWindowsDrive, "file: with host and Windows drive letter"),
-        ("http://mozilla.org/^", NonUrlCodePoint, "non-URL code point",),
+        ("http://mozilla.org/^", NonUrlCodePoint, "non-URL code point"),
         ("http://mozilla.org/#\00", NullInFragment, "NULL characters are ignored in URL fragment identifiers"),
         ("http://mozilla.org/%1", PercentDecode, "expected 2 hex digits after %"),
         ("http://mozilla.org\t/foo", TabOrNewlineIgnored, "tabs or newlines are ignored in URLs"),

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -806,7 +806,8 @@ fn test_syntax_violation_callback_types() {
         let violation = Cell::new(None);
         Url::options()
             .syntax_violation_callback(Some(&|v| violation.set(Some(v))))
-            .parse(test_case.0);
+            .parse(test_case.0)
+            .unwrap();
 
         let v = violation.take();
         assert_eq!(v, Some(test_case.1));


### PR DESCRIPTION
New test coverage:
|| src/parser.rs: 697/848 +1.7688679245283057%