### PR TITLE
Bump minor version number

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "url"
 # When updating version, also modify html_root_url in the lib.rs
-version = "2.2.1"
+version = "2.2.2"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -120,7 +120,7 @@ url = { version = "2", features = ["serde"] }
 ```
 */
 
-#![doc(html_root_url = "https://docs.rs/url/2.2.1")]
+#![doc(html_root_url = "https://docs.rs/url/2.2.2")]
 
 #[macro_use]
 extern crate matches;


### PR DESCRIPTION
This allows Android's automatic importer to pick up the new tests.