### PR TITLE
`no_std` support for all crates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           command: test
           args: --all-features
+      - uses: actions-rs/cargo@v1
+        # --no-default-features only available since 1.51.0
+        if: matrix.rust != '1.45.0'
+        with:
+          command: test
+          args: --no-default-features
 
   WASM:
     runs-on: ubuntu-latest

--- a/data-url/src/forgiving_base64.rs
+++ b/data-url/src/forgiving_base64.rs
@@ -1,5 +1,7 @@
 //! <https://infra.spec.whatwg.org/#forgiving-base64-decode>
 
+use alloc::vec::Vec;
+
 #[derive(Debug)]
 pub struct InvalidBase64(InvalidBase64Details);
 

--- a/data-url/src/lib.rs
+++ b/data-url/src/lib.rs
@@ -14,6 +14,12 @@
 //! assert_eq!(body, b"Hello World!");
 //! assert!(fragment.is_none());
 //! ```
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
 
 macro_rules! require {
     ($condition: expr) => {

--- a/data-url/src/mime.rs
+++ b/data-url/src/mime.rs
@@ -1,5 +1,6 @@
-use std::fmt::{self, Write};
-use std::str::FromStr;
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use core::fmt::{self, Write};
+use core::str::FromStr;
 
 /// <https://mimesniff.spec.whatwg.org/#mime-type-representation>
 #[derive(Debug, PartialEq, Eq)]

--- a/form_urlencoded/src/lib.rs
+++ b/form_urlencoded/src/lib.rs
@@ -12,10 +12,14 @@
 //!
 //! Converts between a string (such as an URL’s query string)
 //! and a sequence of (name, value) pairs.
+#![no_std]
 
+extern crate alloc;
+
+use alloc::borrow::{Borrow, Cow, ToOwned};
+use alloc::string::String;
+use core::str;
 use percent_encoding::{percent_decode, percent_encode_byte};
-use std::borrow::{Borrow, Cow};
-use std::str;
 
 /// Convert a byte string in the `application/x-www-form-urlencoded` syntax
 /// into a iterator of (name, value) pairs.

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -12,6 +12,10 @@ rust-version = "1.45"
 [lib]
 doctest = false
 
+[features]
+default = ["std"]
+std = []
+
 [[test]]
 name = "tests"
 harness = false
@@ -26,8 +30,8 @@ tester = "0.9"
 serde_json = "1.0"
 
 [dependencies]
-unicode-bidi = "0.3"
-unicode-normalization = "0.1.17"
+unicode-bidi = { version = "0.3.7", default-features = false }
+unicode-normalization = { version = "0.1.17", default-features = false }
 
 [[bench]]
 name = "all"

--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -31,10 +31,18 @@
 //! > This document specifies a mechanism
 //! > that minimizes the impact of this transition for client software,
 //! > allowing client software to access domains that are valid under either system.
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
+
+use alloc::string::String;
 
 pub mod punycode;
 mod uts46;

--- a/idna/src/punycode.rs
+++ b/idna/src/punycode.rs
@@ -13,8 +13,9 @@
 //! `encode_str` and `decode_to_string` provide convenience wrappers
 //! that convert from and to Rust’s UTF-8 based `str` and `String` types.
 
-use std::char;
-use std::u32;
+use alloc::{string::String, vec::Vec};
+use core::char;
+use core::u32;
 
 // Bootstring parameters for Punycode
 static BASE: u32 = 36;
@@ -168,7 +169,7 @@ impl Decoder {
 }
 
 pub(crate) struct Decode<'a> {
-    base: std::str::Chars<'a>,
+    base: core::str::Chars<'a>,
     pub(crate) insertions: &'a [(usize, char)],
     inserted: usize,
     position: usize,

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -11,7 +11,9 @@
 
 use self::Mapping::*;
 use crate::punycode;
-use std::{error::Error as StdError, fmt};
+
+use alloc::string::String;
+use core::fmt;
 use unicode_bidi::{bidi_class, BidiClass};
 use unicode_normalization::char::is_combining_mark;
 use unicode_normalization::{is_nfc, UnicodeNormalization};
@@ -70,10 +72,10 @@ fn find_char(codepoint: char) -> &'static Mapping {
 }
 
 struct Mapper<'a> {
-    chars: std::str::Chars<'a>,
+    chars: core::str::Chars<'a>,
     config: Config,
     errors: &'a mut Errors,
-    slice: Option<std::str::Chars<'static>>,
+    slice: Option<core::str::Chars<'static>>,
 }
 
 impl<'a> Iterator for Mapper<'a> {
@@ -697,7 +699,8 @@ impl From<Errors> for Result<(), Errors> {
     }
 }
 
-impl StdError for Errors {}
+#[cfg(feature = "std")]
+impl std::error::Error for Errors {}
 
 impl fmt::Display for Errors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -26,12 +26,13 @@ bencher = "0.1"
 
 [dependencies]
 form_urlencoded = { version = "1.0.0", path = "../form_urlencoded" }
-idna = { version = "0.2.0", path = "../idna", optional = true }
+idna = { version = "0.2.0", default-features = false, path = "../idna", optional = true }
 percent-encoding = { version = "2.1.0", path = "../percent_encoding" }
-serde = {version = "1.0", optional = true, features = ["derive"]}
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 
 [features]
-default = ["idna"]
+default = ["std", "idna"]
+std = ["idna/std"]
 
 [[bench]]
 name = "parse_url"

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -6,8 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp;
-use std::fmt::{self, Formatter};
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::cmp;
+use core::fmt::{self, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use percent_encoding::{percent_decode, utf8_percent_encode, CONTROLS};

--- a/url/src/origin.rs
+++ b/url/src/origin.rs
@@ -9,7 +9,10 @@
 use crate::host::Host;
 use crate::parser::default_port;
 use crate::Url;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use idna::domain_to_unicode;
 
 pub fn url_origin(url: &Url) -> Origin {
     let scheme = url.scheme();

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -6,9 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::error::Error;
-use std::fmt::{self, Formatter, Write};
-use std::str;
+use alloc::borrow::ToOwned;
+use alloc::string::{String, ToString};
+use core::fmt::{self, Formatter, Write};
+use core::str;
 
 use crate::host::{Host, HostInternal};
 use crate::Url;
@@ -72,7 +73,8 @@ macro_rules! simple_enum_error {
     }
 }
 
-impl Error for ParseError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {}
 
 simple_enum_error! {
     EmptyHost => "empty host",
@@ -1107,7 +1109,7 @@ impl<'a> Parser<'a> {
         while let (Some(c), remaining) = input.split_first() {
             if let Some(digit) = c.to_digit(10) {
                 port = port * 10 + digit;
-                if port > ::std::u16::MAX as u32 {
+                if port > core::u16::MAX as u32 {
                     return Err(ParseError::InvalidPort);
                 }
                 has_any_digit = true;
@@ -1541,7 +1543,7 @@ pub fn ascii_alpha(ch: char) -> bool {
 
 #[inline]
 pub fn to_u32(i: usize) -> ParseResult<u32> {
-    if i <= ::std::u32::MAX as usize {
+    if i <= core::u32::MAX as usize {
         Ok(i as u32)
     } else {
         Err(ParseError::Overflow)

--- a/url/src/path_segments.rs
+++ b/url/src/path_segments.rs
@@ -8,7 +8,8 @@
 
 use crate::parser::{self, to_u32, SchemeType};
 use crate::Url;
-use std::str;
+use alloc::string::String;
+use core::str;
 
 /// Exposes methods to manipulate the path of an URL that is not cannot-be-base.
 ///

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -11,6 +11,8 @@
 //! Unless you need to be interoperable with web browsers,
 //! you probably want to use `Url` method instead.
 
+use alloc::string::{String, ToString};
+
 use crate::parser::{default_port, Context, Input, Parser, SchemeType};
 use crate::{Host, ParseError, Position, Url};
 

--- a/url/src/slicing.rs
+++ b/url/src/slicing.rs
@@ -6,8 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
+
 use crate::Url;
-use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 
 impl Index<RangeFull> for Url {
     type Output = str;


### PR DESCRIPTION
Fixes https://github.com/servo/rust-url/issues/609.

~Our dependencies need to support `no_std`~ Done:
- `matches`, support since version `0.1.9`, see https://github.com/SimonSapin/rust-std-candidates/pull/23
- `unicode-bidi`, support since version `0.3.6`, see https://github.com/servo/unicode-bidi/pull/58
- `unicode-normalization`, support since version `0.1.13`, see https://github.com/unicode-rs/unicode-normalization/pull/55

As far as I can see there's a few ways to solve the `std::net` issue noted in the linked issue:
1. Use something like [`no-std-net`](https://github.com/dunmatt/no-std-net) on `no_std` targets. Since that library doesn't have a MSRV, we might need to define that `no_std` support doesn't guarantee a MSRV (until we find a more permanent solution).
2. Change the structure of `Host` to store custom ip address types, and return `std::net` types in functions (that can then be feature gated). Requires a breaking version.
3. Wait until the [RFC](https://github.com/rust-lang/rfcs/pull/2832) is merged, implemented and stabilized, and wait further until they have been around long enough to be in our MSRV.

As far as I can see option 1 is possible now, and it could even (with a little more work on `no-std-net` beforehand) be possible to migrate away from once (if) the RFC is stabilized, all without breaking changes.