### PR TITLE
`no_std` support for `form_urlencoded`, `data-url` and `idna`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
           matrix.os == 'windows-latest' &&
           matrix.rust == 'nightly'
         run: cargo test --test debugger_visualizer --features "url/serde,url/debugger_visualizer" -- --test-threads=1
+      - name: Test `no_std` support
+        run: cargo test --no-default-features --features=alloc
 
   WASM:
     runs-on: ubuntu-latest

--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -3,11 +3,17 @@ name = "data-url"
 version = "0.2.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Processing of data: URL according to WHATWG’s Fetch Standard"
+categories = ["no_std"]
 repository = "https://github.com/servo/rust-url"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 autotests = false
 rust-version = "1.51"
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
 
 [dev-dependencies]
 tester = "0.9"

--- a/data-url/src/forgiving_base64.rs
+++ b/data-url/src/forgiving_base64.rs
@@ -1,5 +1,7 @@
 //! <https://infra.spec.whatwg.org/#forgiving-base64-decode>
 
+use alloc::vec::Vec;
+
 #[derive(Debug)]
 pub struct InvalidBase64(InvalidBase64Details);
 

--- a/data-url/src/lib.rs
+++ b/data-url/src/lib.rs
@@ -24,7 +24,7 @@ extern crate std as _;
 extern crate alloc;
 
 #[cfg(not(feature = "alloc"))]
-compile_error!("the `alloc` feature must currently be enabled");
+compile_error!("the `alloc` feature must be enabled");
 
 use alloc::{string::String, vec::Vec};
 

--- a/data-url/src/lib.rs
+++ b/data-url/src/lib.rs
@@ -14,6 +14,19 @@
 //! assert_eq!(body, b"Hello World!");
 //! assert!(fragment.is_none());
 //! ```
+#![no_std]
+
+// For forwards compatibility
+#[cfg(feature = "std")]
+extern crate std as _;
+
+#[macro_use]
+extern crate alloc;
+
+#[cfg(not(feature = "alloc"))]
+compile_error!("the `alloc` feature must currently be enabled");
+
+use alloc::{string::String, vec::Vec};
 
 macro_rules! require {
     ($condition: expr) => {

--- a/data-url/src/mime.rs
+++ b/data-url/src/mime.rs
@@ -1,5 +1,6 @@
-use std::fmt::{self, Write};
-use std::str::FromStr;
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use core::fmt::{self, Write};
+use core::str::FromStr;
 
 /// <https://mimesniff.spec.whatwg.org/#mime-type-representation>
 #[derive(Debug, PartialEq, Eq)]

--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -3,6 +3,7 @@ name = "form_urlencoded"
 version = "1.1.0"
 authors = ["The rust-url developers"]
 description = "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms."
+categories = ["no_std"]
 repository = "https://github.com/servo/rust-url"
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -11,5 +12,10 @@ rust-version = "1.51"
 [lib]
 test = false
 
+[features]
+default = ["std"]
+std = ["alloc", "percent-encoding/std"]
+alloc = ["percent-encoding/alloc"]
+
 [dependencies]
-percent-encoding = { version = "2.2.0", path = "../percent_encoding" }
+percent-encoding = { version = "2.2.0", default-features = false, path = "../percent_encoding" }

--- a/form_urlencoded/src/lib.rs
+++ b/form_urlencoded/src/lib.rs
@@ -12,10 +12,21 @@
 //!
 //! Converts between a string (such as an URL’s query string)
 //! and a sequence of (name, value) pairs.
+#![no_std]
 
+// For forwards compatibility
+#[cfg(feature = "std")]
+extern crate std as _;
+
+extern crate alloc;
+
+#[cfg(not(feature = "alloc"))]
+compile_error!("the `alloc` feature must currently be enabled");
+
+use alloc::borrow::{Borrow, Cow, ToOwned};
+use alloc::string::String;
+use core::str;
 use percent_encoding::{percent_decode, percent_encode_byte};
-use std::borrow::{Borrow, Cow};
-use std::str;
 
 /// Convert a byte string in the `application/x-www-form-urlencoded` syntax
 /// into a iterator of (name, value) pairs.

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -3,6 +3,7 @@ name = "idna"
 version = "0.3.0"
 authors = ["The rust-url developers"]
 description = "IDNA (Internationalizing Domain Names in Applications) and Punycode."
+categories = ["no_std"]
 repository = "https://github.com/servo/rust-url/"
 license = "MIT OR Apache-2.0"
 autotests = false
@@ -11,6 +12,11 @@ rust-version = "1.51"
 
 [lib]
 doctest = false
+
+[features]
+default = ["std"]
+std = ["alloc", "unicode-bidi/std", "unicode-normalization/std"]
+alloc = []
 
 [[test]]
 name = "tests"
@@ -26,8 +32,8 @@ tester = "0.9"
 serde_json = "1.0"
 
 [dependencies]
-unicode-bidi = "0.3"
-unicode-normalization = "0.1.17"
+unicode-bidi = { version = "0.3.10", default-features = false, features = ["hardcoded-data"] }
+unicode-normalization = { version = "0.1.22", default-features = false }
 
 [[bench]]
 name = "all"

--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -40,7 +40,7 @@ extern crate std;
 extern crate alloc;
 
 #[cfg(not(feature = "alloc"))]
-compile_error!("the `alloc` feature must currently be enabled");
+compile_error!("the `alloc` feature must be enabled");
 
 #[cfg(test)]
 #[macro_use]

--- a/idna/src/lib.rs
+++ b/idna/src/lib.rs
@@ -31,10 +31,22 @@
 //! > This document specifies a mechanism
 //! > that minimizes the impact of this transition for client software,
 //! > allowing client software to access domains that are valid under either system.
+#![no_std]
+
+// For forwards compatibility
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
+#[cfg(not(feature = "alloc"))]
+compile_error!("the `alloc` feature must currently be enabled");
 
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
+
+use alloc::string::String;
 
 pub mod punycode;
 mod uts46;

--- a/idna/src/punycode.rs
+++ b/idna/src/punycode.rs
@@ -13,8 +13,9 @@
 //! `encode_str` and `decode_to_string` provide convenience wrappers
 //! that convert from and to Rust’s UTF-8 based `str` and `String` types.
 
-use std::char;
-use std::u32;
+use alloc::{string::String, vec::Vec};
+use core::char;
+use core::u32;
 
 // Bootstring parameters for Punycode
 static BASE: u32 = 36;
@@ -168,7 +169,7 @@ impl Decoder {
 }
 
 pub(crate) struct Decode<'a> {
-    base: std::str::Chars<'a>,
+    base: core::str::Chars<'a>,
     pub(crate) insertions: &'a [(usize, char)],
     inserted: usize,
     position: usize,

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -11,7 +11,9 @@
 
 use self::Mapping::*;
 use crate::punycode;
-use std::{error::Error as StdError, fmt};
+
+use alloc::string::String;
+use core::fmt;
 use unicode_bidi::{bidi_class, BidiClass};
 use unicode_normalization::char::is_combining_mark;
 use unicode_normalization::{is_nfc, UnicodeNormalization};
@@ -70,10 +72,10 @@ fn find_char(codepoint: char) -> &'static Mapping {
 }
 
 struct Mapper<'a> {
-    chars: std::str::Chars<'a>,
+    chars: core::str::Chars<'a>,
     config: Config,
     errors: &'a mut Errors,
-    slice: Option<std::str::Chars<'static>>,
+    slice: Option<core::str::Chars<'static>>,
 }
 
 impl<'a> Iterator for Mapper<'a> {
@@ -708,7 +710,8 @@ impl From<Errors> for Result<(), Errors> {
     }
 }
 
-impl StdError for Errors {}
+#[cfg(feature = "std")]
+impl std::error::Error for Errors {}
 
 impl fmt::Display for Errors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -3,11 +3,13 @@ name = "percent-encoding"
 version = "2.2.0"
 authors = ["The rust-url developers"]
 description = "Percent encoding and decoding"
+categories = ["no_std"]
 repository = "https://github.com/servo/rust-url/"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 rust-version = "1.51"
 
 [features]
-default = ["alloc"]
+default = ["std"]
+std = ["alloc"]
 alloc = []

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -36,8 +36,12 @@
 //!
 //! assert_eq!(utf8_percent_encode("foo <bar>", FRAGMENT).to_string(), "foo%20%3Cbar%3E");
 //! ```
-
 #![no_std]
+
+// For forwards compatibility
+#[cfg(feature = "std")]
+extern crate std as _;
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 


### PR DESCRIPTION
Split out from https://github.com/servo/rust-url/pull/717.

`no_std` support for `url` is going to take more effort, but we can start with this.

~The builds (if they were run) are failing because of https://github.com/servo/unicode-bidi/pull/63~ Fixed.