### PR TITLE
Cross-platform parsing

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2715,7 +2715,7 @@ fn path_to_file_url_segments_windows(
     let host_end;
     let host_internal;
 
-    match dbg!(components.next()) {
+    match components.next() {
         Some(Component::Prefix(ref p)) => match p.kind() {
             Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => {
                 host_end = to_u32(serialization.len()).unwrap();
@@ -2744,17 +2744,7 @@ fn path_to_file_url_segments_windows(
             }
         },
         Some(Component::Normal(_)) | Some(Component::ParentDir) => return Err(()),
-        Some(Component::RootDir) => {
-            dbg!("found a root dir");
-            // return Err(());
-            host_end = to_u32(serialization.len()).unwrap();
-            host_internal = HostInternal::None;
-            // serialization.push('/')
-            // host_end = to_u32(serialization.len()).unwrap();
-            // host_internal = HostInternal::None;
-        }
         _ => {
-            dbg!("something else");
             host_end = to_u32(serialization.len()).unwrap();
             host_internal = HostInternal::None;
             // serialization.push('/');
@@ -2763,12 +2753,8 @@ fn path_to_file_url_segments_windows(
         }
     }
 
-    dbg!(&serialization);
-
     let mut path_only_has_prefix = true;
     for component in components {
-        dbg!(&component);
-
         if component == Component::RootDir {
             continue;
         }
@@ -2777,7 +2763,6 @@ fn path_to_file_url_segments_windows(
         // FIXME: somehow work with non-unicode?
         let component = component.as_os_str().to_str().ok_or(())?;
 
-        dbg!("asdfsdf");
         serialization.push('/');
         serialization.extend(percent_encode(component.as_bytes(), PATH_SEGMENT));
     }
@@ -2787,7 +2772,6 @@ fn path_to_file_url_segments_windows(
         && parser::is_windows_drive_letter(&serialization[host_start..])
         && path_only_has_prefix
     {
-        dbg!("kujylkiu");
         serialization.push('/');
     }
 

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -851,6 +851,32 @@ fn test_url_from_file_path() {
     assert_eq!("C:\\", path.to_str().unwrap());
 }
 
+/// https://github.com/servo/rust-url/issues/730
+#[cfg(windows)]
+#[test]
+fn test_url_to_invalid_file_path() {
+    use url::Url;
+
+    let u = Url::parse("file:///foo/bar").unwrap();
+    let path = u.to_file_path().unwrap();
+
+    assert_eq!(r"\foo\bar", path.to_str().unwrap());
+}
+
+/// https://github.com/servo/rust-url/issues/730
+#[cfg(windows)]
+#[test]
+fn test_url_from_invalid_file_path() {
+    use std::path::PathBuf;
+    use url::Url;
+
+    let p = PathBuf::from("/foo");
+    let u = Url::from_file_path(p).unwrap();
+
+    let path = u.to_file_path().unwrap();
+    assert_eq!(r"\foo", path.to_str().unwrap());
+}
+
 /// https://github.com/servo/rust-url/issues/505
 #[cfg(not(windows))]
 #[test]

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -125,6 +125,10 @@ fn new_path_windows_fun() {
         // Percent-encoded drive letter
         let url = Url::parse("file:///C%3A/foo/bar").unwrap();
         assert_eq!(url.to_file_path(), Ok(PathBuf::from(r"C:\foo\bar")));
+
+        // Invalid Windows paths should still be able to be created.
+        let url = Url::parse("file:////foo/bar").unwrap();
+        assert_eq!(url.to_file_path(), Ok(PathBuf::from(r"\foo\bar")));
     }
 }
 

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -90,7 +90,10 @@ fn new_file_paths() {
         );
 
         // UNC
-        assert_eq!(Url::from_file_path(Path::new(r"\\server\")), Err(()));
+        assert_eq!(
+            Url::from_file_path(Path::new(r"\\server\")).unwrap(),
+            Url::parse("file:///server").unwrap()
+        );
     }
 
     if cfg!(unix) {
@@ -864,11 +867,10 @@ fn test_url_from_invalid_file_path() {
     use std::path::PathBuf;
     use url::Url;
 
-    let p = PathBuf::from(r"\foo\bar");
-    let u = Url::from_file_path(p).unwrap();
-
-    let path = u.to_file_path().unwrap();
-    assert_eq!(r"\foo\bar", path.to_str().unwrap());
+    assert_eq!(
+        Url::from_file_path(PathBuf::from(r"\foo\bar")).unwrap(),
+        Url::parse("file:///foo/bar").unwrap()
+    );
 }
 
 /// https://github.com/servo/rust-url/issues/505

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -90,7 +90,7 @@ fn new_file_paths() {
         );
 
         // UNC
-        // assert_eq!(Url::from_file_path(Path::new(r"\\server\")), Err(()));
+        assert_eq!(Url::from_file_path(Path::new(r"\\server\")), Err(()));
     }
 
     if cfg!(unix) {
@@ -130,10 +130,6 @@ fn new_path_windows_fun() {
         // Percent-encoded drive letter
         let url = Url::parse("file:///C%3A/foo/bar").unwrap();
         assert_eq!(url.to_file_path(), Ok(PathBuf::from(r"C:\foo\bar")));
-
-        // Invalid Windows paths should still be able to be created.
-        let url = Url::parse("file:////foo/bar").unwrap();
-        assert_eq!(url.to_file_path(), Ok(PathBuf::from(r"\foo\bar")));
     }
 }
 
@@ -859,18 +855,6 @@ fn test_url_from_file_path() {
     let u = Url::from_file_path(p).unwrap();
     let path = u.to_file_path().unwrap();
     assert_eq!("C:\\", path.to_str().unwrap());
-}
-
-/// https://github.com/servo/rust-url/issues/730
-#[cfg(windows)]
-#[test]
-fn test_url_to_invalid_file_path() {
-    use url::Url;
-
-    let u = Url::parse("file:///foo/bar").unwrap();
-    let path = u.to_file_path().unwrap();
-
-    assert_eq!(r"\foo\bar", path.to_str().unwrap());
 }
 
 /// https://github.com/servo/rust-url/issues/730

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -156,7 +156,10 @@ fn new_directory_paths() {
         );
 
         // UNC
-        assert_eq!(Url::from_directory_path(Path::new(r"\\server\")), Err(()));
+        assert_eq!(
+            Url::from_directory_path(Path::new(r"\\server\")).unwrap(),
+            Url::parse("file:///server/").unwrap()
+        );
 
         let url = Url::from_directory_path(Path::new(r"C:\foo\bar")).unwrap();
         assert_eq!(url.host(), None);

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -88,7 +88,9 @@ fn new_file_paths() {
             Url::from_file_path(Path::new(r"\drive-relative")).unwrap(),
             Url::parse("file:///drive-relative").unwrap()
         );
-        // assert_eq!(Url::from_file_path(Path::new(r"\\ucn\")), Err(()));
+
+        // UNC
+        // assert_eq!(Url::from_file_path(Path::new(r"\\server\")), Err(()));
     }
 
     if cfg!(unix) {
@@ -152,7 +154,9 @@ fn new_directory_paths() {
             Url::from_directory_path(Path::new(r"\drive-relative")).unwrap(),
             Url::parse("file:///drive-relative/").unwrap()
         );
-        // assert_eq!(Url::from_directory_path(Path::new(r"\\ucn\")), Err(()));
+
+        // UNC
+        assert_eq!(Url::from_directory_path(Path::new(r"\\server\")), Err(()));
 
         let url = Url::from_directory_path(Path::new(r"C:\foo\bar")).unwrap();
         assert_eq!(url.host(), None);

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -84,8 +84,11 @@ fn new_file_paths() {
     if cfg!(windows) {
         assert_eq!(Url::from_file_path(Path::new("relative")), Err(()));
         assert_eq!(Url::from_file_path(Path::new(r"..\relative")), Err(()));
-        assert_eq!(Url::from_file_path(Path::new(r"\drive-relative")), Err(()));
-        assert_eq!(Url::from_file_path(Path::new(r"\\ucn\")), Err(()));
+        assert_eq!(
+            Url::from_file_path(Path::new(r"\drive-relative")).unwrap(),
+            Url::parse("file:///drive-relative").unwrap()
+        );
+        // assert_eq!(Url::from_file_path(Path::new(r"\\ucn\")), Err(()));
     }
 
     if cfg!(unix) {
@@ -146,10 +149,10 @@ fn new_directory_paths() {
         assert_eq!(Url::from_directory_path(Path::new("relative")), Err(()));
         assert_eq!(Url::from_directory_path(Path::new(r"..\relative")), Err(()));
         assert_eq!(
-            Url::from_directory_path(Path::new(r"\drive-relative")),
-            Err(())
+            Url::from_directory_path(Path::new(r"\drive-relative")).unwrap(),
+            Url::parse("file:///drive-relative/").unwrap()
         );
-        assert_eq!(Url::from_directory_path(Path::new(r"\\ucn\")), Err(()));
+        // assert_eq!(Url::from_directory_path(Path::new(r"\\ucn\")), Err(()));
 
         let url = Url::from_directory_path(Path::new(r"C:\foo\bar")).unwrap();
         assert_eq!(url.host(), None);
@@ -870,11 +873,11 @@ fn test_url_from_invalid_file_path() {
     use std::path::PathBuf;
     use url::Url;
 
-    let p = PathBuf::from("/foo");
+    let p = PathBuf::from(r"\foo\bar");
     let u = Url::from_file_path(p).unwrap();
 
     let path = u.to_file_path().unwrap();
-    assert_eq!(r"\foo", path.to_str().unwrap());
+    assert_eq!(r"\foo\bar", path.to_str().unwrap());
 }
 
 /// https://github.com/servo/rust-url/issues/505


### PR DESCRIPTION
@valenting I'd like to take #730 but would appreciate some feedback on the implementation details:

1. What should `file:///foo/bar` convert to on Windows? I'm currently converting it to `\foo\bar`, but I'm not sure if that's a good idea since that's a Windows drive-relative path, which isn't what the URL was intended to be interpreted as since the URL is missing the drive letter.
2. I moved this [to a conditional](https://github.com/andrewbanchich/rust-url/blob/39a16680e50c9b092c324751296a6c0ff7152072/url/src/lib.rs#L2852) since `\foo\bar` is not absolute.

```rust
    debug_assert!(
        path.is_absolute(),
        "to_file_path() failed to produce an absolute Path"
    );
```

However, I'm not sure if we want to even keep this assertion anymore.

3. I renamed some variables and used `PathBuf` instead of `String` for clarity.
4. The first `match` arm looks like it's checking for a drive letter, but I wasn't sure what [the second arm](https://github.com/servo/rust-url/blob/master/url/src/lib.rs#L2834) is checking for. Could you clarify that please?
5. I fixed what I think was a typo in [this test](https://github.com/servo/rust-url/blob/master/url/tests/unit.rs#L88). Still working on getting that one to pass, so I commented it out for now.