### PR TITLE
Be more detailed in documentation of set_query

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -1524,7 +1524,8 @@ impl Url {
         }
     }
 
-    /// Change this URL’s query string.
+    /// Change this URL’s query string. If `query` is `None`, this URL's 
+    /// query string will be cleared.
     ///
     /// # Examples
     ///

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -1524,7 +1524,7 @@ impl Url {
         }
     }
 
-    /// Change this URL’s query string. If `query` is `None`, this URL's 
+    /// Change this URL’s query string. If `query` is `None`, this URL's
     /// query string will be cleared.
     ///
     /// # Examples


### PR DESCRIPTION
The documentation of `set_query` is somewhat ambiguous in what happens in the case that `query` is `None`, and required looking at the actual implementation.