### PR TITLE
Fix description to match example code

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2150,7 +2150,7 @@ impl Url {
     ///
     /// # Examples
     ///
-    /// Change the URL’s scheme from `https` to `foo`:
+    /// Change the URL’s scheme from `https` to `http`:
     ///
     /// ```
     /// use url::Url;


### PR DESCRIPTION
## Description

Fixes example title from

> [Change the URL’s scheme from `https` to `foo`](https://docs.rs/url/latest/url/struct.Url.html#examples-33) 

to

> Change the URL’s scheme from `https` to `http`
