### PR TITLE
Use `tester` instead of `rustc-test`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   push:
-    branches: ['master']
+    branches: ["master"]
   pull_request:
 
 jobs:
@@ -16,9 +16,9 @@ jobs:
           toolchain: stable
           override: true
       - uses: actions-rs/tarpaulin@v0.1
-      - uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
+      - uses: codecov/codecov-action@v2.1.0
+        # A codecov token is not needed for public repos if the repo is linked
+        # on codecov.io. See https://docs.codecov.com/docs/frequently-asked-questions#where-is-the-repository-upload-token-found
       - uses: actions/upload-artifact@v1
         with:
           name: code-coverage-report

--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.45"
 matches = "0.1"
 
 [dev-dependencies]
-rustc-test = "0.3"
+tester = "0.9"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -22,7 +22,7 @@ name = "unit"
 [dev-dependencies]
 assert_matches = "1.3"
 bencher = "0.1"
-rustc-test = "0.3"
+tester = "0.9"
 serde_json = "1.0"
 
 [dependencies]

--- a/idna/tests/punycode.rs
+++ b/idna/tests/punycode.rs
@@ -63,9 +63,9 @@ pub fn collect_tests<F: FnMut(String, TestFn)>(add_test: &mut F) {
                         };
                         add_test(
                             test_name,
-                            TestFn::dyn_test_fn(move || {
+                            TestFn::DynTestFn(Box::new(move || {
                                 one_test(get_string(&o, "decoded"), get_string(&o, "encoded"))
-                            }),
+                            })),
                         )
                     }
                     _ => panic!(),

--- a/idna/tests/tests.rs
+++ b/idna/tests/tests.rs
@@ -1,4 +1,4 @@
-use rustc_test as test;
+use tester as test;
 
 mod punycode;
 mod uts46;
@@ -8,12 +8,18 @@ fn main() {
     {
         let mut add_test = |name, run| {
             tests.push(test::TestDescAndFn {
-                desc: test::TestDesc::new(test::DynTestName(name)),
+                desc: test::TestDesc {
+                    name: test::DynTestName(name),
+                    ignore: false,
+                    should_panic: test::ShouldPanic::No,
+                    allow_fail: false,
+                    test_type: test::TestType::Unknown,
+                },
                 testfn: run,
             })
         };
         punycode::collect_tests(&mut add_test);
         uts46::collect_tests(&mut add_test);
     }
-    test::test_main(&std::env::args().collect::<Vec<_>>(), tests)
+    test::test_main(&std::env::args().collect::<Vec<_>>(), tests, None)
 }

--- a/idna/tests/uts46.rs
+++ b/idna/tests/uts46.rs
@@ -65,7 +65,7 @@ pub fn collect_tests<F: FnMut(String, TestFn)>(add_test: &mut F) {
         let test_name = format!("UTS #46 line {}", i + 1);
         add_test(
             test_name,
-            TestFn::dyn_test_fn(move || {
+            TestFn::DynTestFn(Box::new(move || {
                 let config = idna::Config::default()
                     .use_std3_ascii_rules(true)
                     .verify_dns_length(true)
@@ -109,7 +109,7 @@ pub fn collect_tests<F: FnMut(String, TestFn)>(add_test: &mut F) {
                     to_ascii_t_result,
                     |e| e.starts_with('C') || e == "V2",
                 );
-            }),
+            })),
         )
     }
 }


### PR DESCRIPTION
This commit switches the test library used by idna/tests and
data-url/tests to `tester`. Just like `rustc-test` this is a fork of
the `test` crate inside of `rustc`, but it is much more up to date.

`cargo deny` and `cargo tarpaulin` are both now not complaining anymore.

Closes #746