### PR TITLE
Update Rust MSRV to 1.45

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['master']
+    branches: ["master"]
   pull_request:
 
 jobs:
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.36.0, stable, beta, nightly]
+        rust: [1.45.0, stable, beta, nightly]
         exclude:
           - os: macos-latest
-            rust: 1.36.0
+            rust: 1.45.0
           - os: windows-latest
-            rust: 1.36.0
+            rust: 1.45.0
           - os: macos-latest
             rust: beta
           - os: windows-latest
@@ -81,5 +81,5 @@ jobs:
   Audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2016 The rust-url developers
+Copyright (c) 2013-2022 The rust-url developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/servo/rust-url"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 autotests = false
+rust-version = "1.45"
 
 [dependencies]
 matches = "0.1"

--- a/data-url/src/mime.rs
+++ b/data-url/src/mime.rs
@@ -62,7 +62,6 @@ fn split2(s: &str, separator: char) -> (&str, Option<&str>) {
     (first, iter.next())
 }
 
-#[allow(clippy::manual_strip)] // introduced in 1.45, MSRV is 1.36
 fn parse_parameters(s: &str, parameters: &mut Vec<(String, String)>) {
     let mut semicolon_separated = s.split(';');
 
@@ -73,10 +72,10 @@ fn parse_parameters(s: &str, parameters: &mut Vec<(String, String)>) {
             continue;
         }
         if let Some(value) = value {
-            let value = if value.starts_with('"') {
-                let max_len = value.len().saturating_sub(2); // without start or end quotes
+            let value = if let Some(stripped) = value.strip_prefix('"') {
+                let max_len = stripped.len().saturating_sub(1); // without end quote
                 let mut unescaped_value = String::with_capacity(max_len);
-                let mut chars = value[1..].chars();
+                let mut chars = stripped.chars();
                 'until_closing_quote: loop {
                     while let Some(c) = chars.next() {
                         match c {

--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -6,6 +6,7 @@ description = "Parser and serializer for the application/x-www-form-urlencoded s
 repository = "https://github.com/servo/rust-url"
 license = "MIT/Apache-2.0"
 edition = "2018"
+rust-version = "1.45"
 
 [lib]
 test = false

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/servo/rust-url/"
 license = "MIT/Apache-2.0"
 autotests = false
 edition = "2018"
+rust-version = "1.45"
 
 [lib]
 doctest = false

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -319,7 +319,6 @@ fn check_validity(label: &str, config: Config, errors: &mut Errors) {
 }
 
 /// http://www.unicode.org/reports/tr46/#Processing
-#[allow(clippy::manual_strip)] // introduced in 1.45, MSRV is 1.36
 fn processing(
     domain: &str,
     config: Config,
@@ -384,8 +383,8 @@ fn processing(
             output.push('.');
         }
         first = false;
-        if label.starts_with(PUNYCODE_PREFIX) {
-            match decoder.decode(&label[PUNYCODE_PREFIX.len()..]) {
+        if let Some(remainder) = label.strip_prefix(PUNYCODE_PREFIX) {
+            match decoder.decode(remainder) {
                 Ok(decode) => {
                     let start = output.len();
                     output.extend(decode);

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -6,6 +6,7 @@ description = "Percent encoding and decoding"
 repository = "https://github.com/servo/rust-url/"
 license = "MIT/Apache-2.0"
 edition = "2018"
+rust-version = "1.45"
 
 [features]
 default = ["alloc"]

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["parser-implementations", "web-programming", "encoding"]
 license = "MIT/Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
+rust-version = "1.45"
 
 [badges]
 travis-ci = { repository = "servo/rust-url" }

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -1244,14 +1244,9 @@ impl Url {
     /// # }
     /// # run().unwrap();
     /// ```
-    #[allow(clippy::manual_strip)] // introduced in 1.45, MSRV is 1.36
     pub fn path_segments(&self) -> Option<str::Split<'_, char>> {
         let path = self.path();
-        if path.starts_with('/') {
-            Some(path[1..].split('/'))
-        } else {
-            None
-        }
+        path.strip_prefix('/').map(|remainder| remainder.split('/'))
     }
 
     /// Return this URL’s query string, if any, as a percent-encoded ASCII string.
@@ -1361,8 +1356,7 @@ impl Url {
     }
 
     fn mutate<F: FnOnce(&mut Parser<'_>) -> R, R>(&mut self, f: F) -> R {
-        #[allow(clippy::mem_replace_with_default)] // introduced in 1.40, MSRV is 1.36
-        let mut parser = Parser::for_setter(mem::replace(&mut self.serialization, String::new()));
+        let mut parser = Parser::for_setter(mem::take(&mut self.serialization));
         let result = f(&mut parser);
         self.serialization = parser.serialization;
         result

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -52,15 +52,12 @@ macro_rules! simple_enum_error {
         ///
         /// This may be extended in the future so exhaustive matching is
         /// discouraged with an unused variant.
-        #[allow(clippy::manual_non_exhaustive)] // introduced in 1.40, MSRV is 1.36
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+        #[non_exhaustive]
         pub enum ParseError {
             $(
                 $name,
             )+
-            /// Unused variant enable non-exhaustive matching
-            #[doc(hidden)]
-            __FutureProof,
         }
 
         impl fmt::Display for ParseError {
@@ -69,9 +66,6 @@ macro_rules! simple_enum_error {
                     $(
                         ParseError::$name => fmt.write_str($description),
                     )+
-                    ParseError::__FutureProof => {
-                        unreachable!("Don't abuse the FutureProof!");
-                    }
                 }
             }
         }
@@ -106,15 +100,12 @@ macro_rules! syntax_violation_enum {
         ///
         /// This may be extended in the future so exhaustive matching is
         /// discouraged with an unused variant.
-        #[allow(clippy::manual_non_exhaustive)] // introduced in 1.40, MSRV is 1.36
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+        #[non_exhaustive]
         pub enum SyntaxViolation {
             $(
                 $name,
             )+
-            /// Unused variant enable non-exhaustive matching
-            #[doc(hidden)]
-            __FutureProof,
         }
 
         impl SyntaxViolation {
@@ -123,9 +114,6 @@ macro_rules! syntax_violation_enum {
                     $(
                         SyntaxViolation::$name => $description,
                     )+
-                    SyntaxViolation::__FutureProof => {
-                        unreachable!("Don't abuse the FutureProof!");
-                    }
                 }
             }
         }

--- a/url/tests/data.rs
+++ b/url/tests/data.rs
@@ -8,7 +8,6 @@
 
 //! Data-driven tests
 
-use std::ops::Deref;
 use std::str::FromStr;
 
 use serde_json::Value;
@@ -112,7 +111,6 @@ fn urltestdata() {
     assert!(passed)
 }
 
-#[allow(clippy::option_as_ref_deref)] // introduced in 1.40, MSRV is 1.36
 #[test]
 fn setters_tests() {
     let mut json = Value::from_str(include_str!("setters_tests.json"))
@@ -141,7 +139,7 @@ fn setters_tests() {
             let mut expected = test.take_key("expected").unwrap();
 
             let mut url = Url::parse(&href).unwrap();
-            let comment_ref = comment.as_ref().map(|s| s.deref());
+            let comment_ref = comment.as_deref();
             passed &= check_invariants(&url, &name, comment_ref);
             let _ = set(&mut url, attr, &new_value);
 


### PR DESCRIPTION
The earliest Rust version with all of the standard library features we'd like to make use of is 1.45. The only feature this does not have yet is `edition = 2021`, but other than looking nice, that would have no effect on `rust-url` anyway.

I recommend we bump the MSRV to 1.45 instead of 1.56 then, to minimize breakage across the ecosystem.

Closes #745