### PR TITLE
fix: make_relative missing filename when filenames equal in both urls

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -470,7 +470,7 @@ impl Url {
         }
 
         // Add the filename if they are not the same
-        if base_filename != url_filename {
+        if !relative.is_empty() || base_filename != url_filename {
             // If the URIs filename is empty this means that it was a directory
             // so we'll have to append a '/'.
             //

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1084,6 +1084,16 @@ fn test_make_relative() {
             "http://127.0.0.1:8080/test/video?baz=meh#456",
             "video?baz=meh#456",
         ),
+        (
+            "http://127.0.0.1:8080/file.txt",
+            "http://127.0.0.1:8080/test/file.txt",
+            "test/file.txt",
+        ),
+        (
+            "http://127.0.0.1:8080/not_equal.txt",
+            "http://127.0.0.1:8080/test/file.txt",
+            "test/file.txt",
+        ),
     ];
 
     for (base, uri, relative) in &tests {


### PR DESCRIPTION
```rust
let from_path = url::Url:::parse("http://127.0.0.1:8080/file.txt").unwrap();
let to_path = url::Url:::parse("http://127.0.0.1:8080/test/file.txt").unwrap();
println!("{}", from_path.make_relative(&to_path).unwrap());
```

Expected: `"test/file.txt"`
Actual: `"test"`

Not sure if this expected is correct or if the solution is right, but it passes the tests.