### PR TITLE
Update the minimum rust-version to 1.51 to fix Rust 1.45.0 CI failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.45.0, stable, beta, nightly]
+        rust: [1.51.0, stable, beta, nightly]
         exclude:
           - os: macos-latest
-            rust: 1.45.0
+            rust: 1.51.0
           - os: windows-latest
-            rust: 1.45.0
+            rust: 1.51.0
           - os: macos-latest
             rust: beta
           - os: windows-latest

--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/servo/rust-url"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 autotests = false
-rust-version = "1.45"
+rust-version = "1.51"
 
 [dev-dependencies]
 tester = "0.9"

--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -6,7 +6,7 @@ description = "Parser and serializer for the application/x-www-form-urlencoded s
 repository = "https://github.com/servo/rust-url"
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.51"
 
 [lib]
 test = false

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/servo/rust-url/"
 license = "MIT OR Apache-2.0"
 autotests = false
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.51"
 
 [lib]
 doctest = false

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -6,7 +6,7 @@ description = "Percent encoding and decoding"
 repository = "https://github.com/servo/rust-url/"
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.51"
 
 [features]
 default = ["alloc"]

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["parser-implementations", "web-programming", "encoding"]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.51"
 
 [badges]
 travis-ci = { repository = "servo/rust-url" }

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -143,7 +143,7 @@ impl fmt::Display for SyntaxViolation {
     }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum SchemeType {
     File,
     SpecialNotFile,
@@ -1561,7 +1561,7 @@ pub fn is_windows_drive_letter(segment: &str) -> bool {
 /// Whether path starts with a root slash
 /// and a windows drive letter eg: "/c:" or "/a:/"
 fn path_starts_with_windows_drive_letter(s: &str) -> bool {
-    if let Some(c) = s.as_bytes().get(0) {
+    if let Some(c) = s.as_bytes().first() {
         matches!(c, b'/' | b'\\' | b'?' | b'#') && starts_with_windows_drive_letter(&s[1..])
     } else {
         false


### PR DESCRIPTION
The Rust 1.45.0 CI job has started failing due to an update of the `serde` and `serde_derive` crates. The latest updates to these crates causes cargo to require the `resolver` feature which was unstable in the version of cargo shipped in the Rust 1.45.0 toolchain.

This feature has since been stabilized in the version of cargo shipped with the Rust 1.51.0 toolchain.

This change updates the minimum `rust-version` to Rust 1.51.0 and updates the github actions workflow to test against Rust 1.51.0 instead of Rust 1.45.0

Linked issue: https://github.com/servo/rust-url/issues/785