### PR TITLE
perf(url): minimize `String::push` calls in parse_scheme

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2243,7 +2243,7 @@ impl Url {
     #[allow(clippy::result_unit_err, clippy::suspicious_operation_groupings)]
     pub fn set_scheme(&mut self, scheme: &str) -> Result<(), ()> {
         let mut parser = Parser::for_setter(String::new());
-        let remaining = parser.parse_scheme(parser::Input::new(scheme))?;
+        let remaining = parser::Input::new(parser.parse_scheme(scheme)?);
         let new_scheme_type = SchemeType::from(&parser.serialization);
         let old_scheme_type = SchemeType::from(self.scheme());
         // If url’s scheme is a special scheme and buffer is not a special scheme, then return.


### PR DESCRIPTION
Minimize calls to `String::push` into a single allocation after encoutering `:` in `parse_scheme`. 

~1.5x improvement in `Url::parse("http://example.com")?`

main:
```
time 353 ms rate 2831289
time 353 ms rate 2830078
time 354 ms rate 2821986
time 353 ms rate 2829860
time 353 ms rate 2829671
time 354 ms rate 2821004
time 353 ms rate 2831683
time 353 ms rate 2830756
time 353 ms rate 2830787
time 352 ms rate 2834233
```

This patch:
```
time 308 ms rate 3245196
time 308 ms rate 3240815
time 306 ms rate 3261353
time 306 ms rate 3259889
time 309 ms rate 3227921
time 306 ms rate 3260827
time 306 ms rate 3262840
time 309 ms rate 3235442
time 308 ms rate 3239239
time 306 ms rate 3264659
```

This patch + @AaronO's https://github.com/servo/rust-url/pull/761:
```
time 206 ms rate 4833188
time 206 ms rate 4854101
time 206 ms rate 4853265
time 206 ms rate 4838242
time 211 ms rate 4721031
time 206 ms rate 4842378
time 205 ms rate 4857185
time 205 ms rate 4855094
time 206 ms rate 4841436
```

<details><summary>Benchmark code</summary>

```rust
const COUNT: usize = 1000000;
for _ in 0..10 {
    let start = std::time::Instant::now();
    for _ in 0..COUNT {
      let url = url::Url::parse("http://www.example.com/").unwrap();
    }
    let elasped = start.elapsed();
    let rate = COUNT as f64 / elasped.as_secs_f64();
    println!("time {} ms rate {}", elasped.as_millis(), rate.round());
}
```

</details>