### PR TITLE
add `description` method to `ParseError`

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -60,6 +60,16 @@ macro_rules! simple_enum_error {
             )+
         }
 
+        impl ParseError {
+            pub fn description(&self) -> &'static str {
+                match *self {
+                    $(
+                        ParseError::$name => $description,
+                    )+
+                }
+            }
+        }
+
         impl fmt::Display for ParseError {
             fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
                 match *self {

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1206,3 +1206,11 @@ fn test_authority() {
         "%C3%A0lex:%C3%A0lex@xn--lex-8ka.xn--p1ai.example.com"
     );
 }
+
+#[test]
+fn test_parse_error_description() {
+    match Url::parse("http://") {
+        Ok(_) => panic!("expected error"),
+        Err(e) => assert_eq!(e.description(), "empty host"),
+    }
+}


### PR DESCRIPTION
fix #801