### PR TITLE
Fix anarchist URL where path starts with //

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -683,7 +683,14 @@ impl Url {
             assert_eq!(self.host_end, self.scheme_end + 1);
             assert_eq!(self.host, HostInternal::None);
             assert_eq!(self.port, None);
-            assert_eq!(self.path_start, self.scheme_end + 1);
+            if self.path().starts_with("//") {
+                // special case when first path segment is empty
+                assert_eq!(self.byte_at(self.scheme_end + 1), b'/');
+                assert_eq!(self.byte_at(self.scheme_end + 2), b'.');
+                assert_eq!(self.path_start, self.scheme_end + 3);
+            } else {
+                assert_eq!(self.path_start, self.scheme_end + 1);
+            }
         }
         if let Some(start) = self.query_start {
             assert!(start >= self.path_start);

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -819,37 +819,6 @@ impl<'a> Parser<'a> {
                         self.parse_path(scheme_type, &mut true, base_url.path_start as usize, input)
                     }
                 };
-                // Special case for anarchist URL's with a leading empty segment
-                let scheme_end = base_url.scheme_end as usize;
-                let mut path_start = base_url.path_start as usize;
-                if !base_url.has_authority() {
-                    if path_start == scheme_end + 1 {
-                        // The path starts right after the scheme_end
-                        if self.serialization[path_start..].starts_with("//") {
-                            // Case 1: The base URL did not have an empty segment, but the resulting one does
-                            // Insert the "/." prefix
-                            self.serialization.insert_str(path_start, "/.");
-                            path_start += 2;
-                        }
-                    } else {
-                        assert_eq!(path_start, scheme_end + 3);
-                        assert_eq!(&self.serialization[scheme_end..path_start], ":/.");
-                        // The base URL has a "/." between the host and the path
-                        assert_eq!(
-                            self.serialization.as_bytes().get(path_start).copied(),
-                            Some(b'/')
-                        );
-                        if self.serialization.as_bytes().get(path_start + 1).copied() != Some(b'/')
-                        {
-                            // Case 2: The base URL had an empty segment, but the resulting one does not
-                            // Remove the "/." prefix
-                            self.serialization
-                                .replace_range(scheme_end..path_start, ":");
-                            path_start -= 2;
-                        }
-                    }
-                    assert!(!self.serialization[scheme_end..].starts_with("://"));
-                }
                 self.with_query_and_fragment(
                     scheme_type,
                     base_url.scheme_end,
@@ -858,7 +827,7 @@ impl<'a> Parser<'a> {
                     base_url.host_end,
                     base_url.host,
                     base_url.port,
-                    to_u32(path_start)?,
+                    base_url.path_start,
                     remaining,
                 )
             }
@@ -1397,6 +1366,39 @@ impl<'a> Parser<'a> {
         path_start: u32,
         remaining: Input<'_>,
     ) -> ParseResult<Url> {
+        // Special case for anarchist URL's with a leading empty path segment
+        let scheme_end = scheme_end as usize;
+        let mut path_start = path_start as usize;
+        if path_start == scheme_end + 1 {
+            // Anarchist URL
+            if self.serialization[path_start..].starts_with("//") {
+                // Case 1: The base URL did not have an empty path segment, but the resulting one does
+                // Insert the "/." prefix
+                self.serialization.insert_str(path_start, "/.");
+                path_start += 2;
+            }
+            assert!(!self.serialization[scheme_end..].starts_with("://"));
+        } else if path_start == scheme_end + 3
+            && &self.serialization[scheme_end..path_start] == ":/."
+        {
+            // Anarchist URL with leading empty path segment
+            // The base URL has a "/." between the host and the path
+            assert_eq!(
+                self.serialization.as_bytes().get(path_start).copied(),
+                Some(b'/')
+            );
+            if self.serialization.as_bytes().get(path_start + 1).copied() != Some(b'/') {
+                // Case 2: The base URL had an empty path segment, but the resulting one does not
+                // Remove the "/." prefix
+                self.serialization
+                    .replace_range(scheme_end..path_start, ":");
+                path_start -= 2;
+            }
+            assert!(!self.serialization[scheme_end..].starts_with("://"));
+        }
+        let scheme_end = to_u32(scheme_end)?;
+        let path_start = to_u32(path_start)?;
+
         let (query_start, fragment_start) =
             self.parse_query_and_fragment(scheme_type, scheme_end, remaining)?;
         Ok(Url {

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1380,13 +1380,7 @@ impl<'a> Parser<'a> {
         {
             // Anarchist URL with leading empty path segment
             // The base URL has a "/." between the host and the path
-            assert_eq!(
-                self.serialization
-                    .as_bytes()
-                    .get(path_start_as_usize)
-                    .copied(),
-                Some(b'/')
-            );
+            assert_eq!(self.serialization.as_bytes()[path_start_as_usize], b'/');
             if self
                 .serialization
                 .as_bytes()

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1281,6 +1281,16 @@ impl<'a> Parser<'a> {
             self.serialization.push_str(path.trim_start_matches('/'));
         }
 
+        // This prevents web+demo:/.//not-a-host/ or web+demo:/path/..//not-a-host/,
+        // when parsed and then serialized, from ending up as web+demo://not-a-host/
+        // (they end up as web+demo:/.//not-a-host/).
+        if !*has_host && self.serialization[path_start..].starts_with("//") {
+            // If url’s host is null, url does not have an opaque path,
+            // url’s path’s size is greater than 1, and url’s path[0] is the empty string,
+            // then append U+002F (/) followed by U+002E (.) to output.
+            self.serialization.insert_str(path_start, "/.");
+        }
+
         input
     }
 

--- a/url/src/slicing.rs
+++ b/url/src/slicing.rs
@@ -149,7 +149,14 @@ impl Url {
                 }
             }
 
-            Position::AfterPort => self.path_start as usize,
+            Position::AfterPort => {
+                if let Some(port) = self.port {
+                    debug_assert!(self.byte_at(self.host_end) == b':');
+                    self.host_end as usize + ":".len() + port.to_string().len()
+                } else {
+                    self.host_end as usize
+                }
+            }
 
             Position::BeforePath => self.path_start as usize,
 

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -955,6 +955,16 @@ fn no_panic() {
 }
 
 #[test]
+fn test_null_host_with_leading_empty_path_segment() {
+    // since Note in item 3 of URL serializing in the URL Standard
+    // https://url.spec.whatwg.org/#url-serializing
+    let url = Url::parse("m:/.//\\").unwrap();
+    let encoded = url.as_str();
+    let reparsed = Url::parse(encoded).unwrap();
+    assert_eq!(reparsed, url);
+}
+
+#[test]
 fn pop_if_empty_in_bounds() {
     let mut url = Url::parse("m://").unwrap();
     let mut segments = url.path_segments_mut().unwrap();

--- a/url/tests/urltestdata.json
+++ b/url/tests/urltestdata.json
@@ -7487,7 +7487,6 @@
     "hash": ""
   },
   "Serialize /. in path",
-  "skip next",
   {
     "input": "non-spec:/.//",
     "base": "about:blank",
@@ -7502,7 +7501,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "non-spec:/..//",
     "base": "about:blank",
@@ -7517,7 +7515,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "non-spec:/a/..//",
     "base": "about:blank",
@@ -7532,7 +7529,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "non-spec:/.//path",
     "base": "about:blank",
@@ -7547,7 +7543,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "non-spec:/..//path",
     "base": "about:blank",
@@ -7562,7 +7557,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "non-spec:/a/..//path",
     "base": "about:blank",
@@ -7637,7 +7631,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "",
     "base": "non-spec:/..//p",
@@ -7652,7 +7645,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "path",
     "base": "non-spec:/..//p",

--- a/url/tests/urltestdata.json
+++ b/url/tests/urltestdata.json
@@ -7586,7 +7586,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "/..//path",
     "base": "non-spec:/p",

--- a/url/tests/urltestdata.json
+++ b/url/tests/urltestdata.json
@@ -7601,7 +7601,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "..//path",
     "base": "non-spec:/p",
@@ -7616,7 +7615,6 @@
     "search": "",
     "hash": ""
   },
-  "skip next",
   {
     "input": "a/..//path",
     "base": "non-spec:/p",
@@ -7660,7 +7658,6 @@
     "hash": ""
   },
   "Do not serialize /. in path",
-  "skip next",
   {
     "input": "../path",
     "base": "non-spec:/.//p",

--- a/url/tests/urltestdata.json
+++ b/url/tests/urltestdata.json
@@ -7668,6 +7668,7 @@
     "hash": ""
   },
   "Do not serialize /. in path",
+  "skip next",
   {
     "input": "../path",
     "base": "non-spec:/.//p",


### PR DESCRIPTION
This PR closes https://github.com/servo/rust-url/issues/799 by refusing to parse URLs with no authority whose normalized path would start with a double-slash.

---

The issue comes from the [remove dot segments](https://www.rfc-editor.org/rfc/rfc3986#section-5.2.4) step. Let's consider the URI `m:/.//`. Then, according to the RFC:

> B.  if the input buffer begins with a prefix of "/./" […], then replace that prefix with "/"

So it should be normalized to `m://`, but this has different semantics (resulting in `\` being interpreted as being part of the authority in the original example).

I have conducted a few tests with some URI normalization libraries:

```
$ node test.js
http://example.com/a/c/d
m:/.//
$ cat test.php
<?php
require_once 'URLNormalizer.php';
echo (new Normalizer('http://example.com/a/b/../c/d'))->normalize(), "\n";
echo (new Normalizer('m:/.//'))->normalize(), "\n";
?>
$ php test.php
http://example.com/a/c/d
m:/
$ cat test.pl
use feature qw(say);
use URI::Normalize qw(normalize_uri);
say normalize_uri(URI->new('http://example.com/a/b/../c/d'));
say normalize_uri(URI->new('m:/.//'));
$ perl test.pl
http://example.com/a/c/d
m://
$ cat test.rb
require 'addressable/uri'
p Addressable::URI.parse('http://example.com/a/b/../c/d').normalize.to_s
p Addressable::URI.parse('m:/.//').normalize.to_s
$ ruby test.rb
"http://example.com/a/c/d"
/usr/share/rubygems-integration/all/gems/addressable-2.8.1/lib/addressable/uri.rb:2487:in `validate': Cannot have a path with two leading slashes without an authority set: 'm://' (Addressable::URI::InvalidURIError)
	from /usr/share/rubygems-integration/all/gems/addressable-2.8.1/lib/addressable/uri.rb:2410:in `defer_validation'
	from /usr/share/rubygems-integration/all/gems/addressable-2.8.1/lib/addressable/uri.rb:839:in `initialize'
	from /usr/share/rubygems-integration/all/gems/addressable-2.8.1/lib/addressable/uri.rb:2184:in `new'
	from /usr/share/rubygems-integration/all/gems/addressable-2.8.1/lib/addressable/uri.rb:2184:in `normalize'
	from test.rb:3:in `<main>'
```

For PHP, I am using https://github.com/glenscott/url-normalizer. In short:

- Node does not remove the dot before a double-slash; I think the logic is [somewhere in there](https://searchfox.org/mozilla-central/source/netwerk/base/nsNetUtil.cpp#1815), but I never liked browsing Firefox's source code, so who knows?
- PHP removes the dot but avoids leaving a double-slash where it would be reinterpreted as the authority; this is done by [merging consecutive slashes](https://github.com/glenscott/url-normalizer/blob/master/src/URL/Normalizer.php#L262), which is does not conform to the RFC
- Perl exhibits the same bug as `rust-url`
- Ruby straight up refuses to parse a path with two leading slashes without an authority

I feel like Ruby's is the most consistent and straightforward solution.

This does mean that the [`no_panic` test](https://github.com/servo/rust-url/blob/master/url/tests/unit.rs#L951) from https://github.com/servo/rust-url/issues/654 must be amended. However, we can cover the `m:/.//` case in a dedicated unit test.