### PR TITLE
Replace Host::IPv4/IPv6 with single variant taking IpAddr

### DIFF
--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -80,7 +80,7 @@ impl Host<String> {
             }
             return parse_ipv6addr(&input[1..input.len() - 1])
                 .map(IpAddr::V6)
-                .map(|x| x.into());
+                .map(From::from);
         }
         let domain = percent_decode(input.as_bytes()).decode_utf8_lossy();
 

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -63,7 +63,7 @@ impl<'a> Host<&'a str> {
     }
 }
 
-impl<T> From<IpAddr> for Host<T> {
+impl<S> From<IpAddr> for Host<S> {
     fn from(address: IpAddr) -> Self {
         Host::Ip(address)
     }

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -653,7 +653,7 @@ impl Url {
                 HostInternal::None => assert_eq!(host_str, ""),
                 HostInternal::Ipv4(address) => assert_eq!(host_str, address.to_string()),
                 HostInternal::Ipv6(address) => {
-                    let h: Host<String> = Host::Ipv6(address);
+                    let h: Host<String> = Host::Ip(address.into());
                     assert_eq!(host_str, h.to_string())
                 }
                 HostInternal::Domain => {
@@ -1086,8 +1086,8 @@ impl Url {
         match self.host {
             HostInternal::None => None,
             HostInternal::Domain => Some(Host::Domain(self.slice(self.host_start..self.host_end))),
-            HostInternal::Ipv4(address) => Some(Host::Ipv4(address)),
-            HostInternal::Ipv6(address) => Some(Host::Ipv6(address)),
+            HostInternal::Ipv4(address) => Some(Host::Ip(address.into())),
+            HostInternal::Ipv6(address) => Some(Host::Ip(address.into())),
         }
     }
 
@@ -1232,8 +1232,7 @@ impl Url {
         )?;
         Ok(match host {
             Host::Domain(domain) => (domain, port).to_socket_addrs()?.collect(),
-            Host::Ipv4(ip) => vec![(ip, port).into()],
-            Host::Ipv6(ip) => vec![(ip, port).into()],
+            Host::Ip(ip) => vec![(ip, port).into()],
         })
     }
 
@@ -2022,11 +2021,7 @@ impl Url {
             return Err(());
         }
 
-        let address = match address {
-            IpAddr::V4(address) => Host::Ipv4(address),
-            IpAddr::V6(address) => Host::Ipv6(address),
-        };
-        self.set_host_internal(address, None);
+        self.set_host_internal(address.into(), None);
         Ok(())
     }
 

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -271,9 +271,12 @@ fn host() {
     );
     assert_host(
         "http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]",
-        Host::Ip(Ipv6Addr::new(
-            0x2001, 0x0db8, 0x85a3, 0x08d3, 0x1319, 0x8a2e, 0x0370, 0x7344,
-        ).into()),
+        Host::Ip(
+            Ipv6Addr::new(
+                0x2001, 0x0db8, 0x85a3, 0x08d3, 0x1319, 0x8a2e, 0x0370, 0x7344,
+            )
+            .into(),
+        ),
     );
     assert_host(
         "http://[::]",
@@ -287,7 +290,10 @@ fn host() {
         "http://0x1.0X23.0x21.061",
         Host::Ip(Ipv4Addr::new(1, 35, 33, 49).into()),
     );
-    assert_host("http://0x1232131", Host::Ip(Ipv4Addr::new(1, 35, 33, 49).into()));
+    assert_host(
+        "http://0x1232131",
+        Host::Ip(Ipv4Addr::new(1, 35, 33, 49).into()),
+    );
     assert_host("http://111", Host::Ip(Ipv4Addr::new(0, 0, 0, 111).into()));
     assert!(Url::parse("http://1.35.+33.49").is_err());
     assert!(Url::parse("http://2..2.3").is_err());
@@ -780,7 +786,10 @@ fn test_windows_unc_path() {
     assert_eq!(url.as_str(), "file://xn--hst-sna/share/path/file.txt");
 
     let url = Url::from_file_path(Path::new(r"\\192.168.0.1\share\path\file.txt")).unwrap();
-    assert_eq!(url.host(), Some(Host::Ip(Ipv4Addr::new(192, 168, 0, 1).into())));
+    assert_eq!(
+        url.host(),
+        Some(Host::Ip(Ipv4Addr::new(192, 168, 0, 1).into()))
+    );
 
     let path = url.to_file_path().unwrap();
     assert_eq!(path.to_str(), Some(r"\\192.168.0.1\share\path\file.txt"));

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -267,28 +267,28 @@ fn host() {
     assert_host("http://www.mozilla.org", Host::Domain("www.mozilla.org"));
     assert_host(
         "http://1.35.33.49",
-        Host::Ipv4(Ipv4Addr::new(1, 35, 33, 49)),
+        Host::Ip(Ipv4Addr::new(1, 35, 33, 49).into()),
     );
     assert_host(
         "http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]",
-        Host::Ipv6(Ipv6Addr::new(
+        Host::Ip(Ipv6Addr::new(
             0x2001, 0x0db8, 0x85a3, 0x08d3, 0x1319, 0x8a2e, 0x0370, 0x7344,
-        )),
+        ).into()),
     );
     assert_host(
         "http://[::]",
-        Host::Ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+        Host::Ip(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).into()),
     );
     assert_host(
         "http://[::1]",
-        Host::Ipv6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+        Host::Ip(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into()),
     );
     assert_host(
         "http://0x1.0X23.0x21.061",
-        Host::Ipv4(Ipv4Addr::new(1, 35, 33, 49)),
+        Host::Ip(Ipv4Addr::new(1, 35, 33, 49).into()),
     );
-    assert_host("http://0x1232131", Host::Ipv4(Ipv4Addr::new(1, 35, 33, 49)));
-    assert_host("http://111", Host::Ipv4(Ipv4Addr::new(0, 0, 0, 111)));
+    assert_host("http://0x1232131", Host::Ip(Ipv4Addr::new(1, 35, 33, 49).into()));
+    assert_host("http://111", Host::Ip(Ipv4Addr::new(0, 0, 0, 111).into()));
     assert!(Url::parse("http://1.35.+33.49").is_err());
     assert!(Url::parse("http://2..2.3").is_err());
     assert!(Url::parse("http://42.0x1232131").is_err());
@@ -780,7 +780,7 @@ fn test_windows_unc_path() {
     assert_eq!(url.as_str(), "file://xn--hst-sna/share/path/file.txt");
 
     let url = Url::from_file_path(Path::new(r"\\192.168.0.1\share\path\file.txt")).unwrap();
-    assert_eq!(url.host(), Some(Host::Ipv4(Ipv4Addr::new(192, 168, 0, 1))));
+    assert_eq!(url.host(), Some(Host::Ip(Ipv4Addr::new(192, 168, 0, 1).into())));
 
     let path = url.to_file_path().unwrap();
     assert_eq!(path.to_str(), Some(r"\\192.168.0.1\share\path\file.txt"));


### PR DESCRIPTION
This change will make it easier to use the Host enum in a more generic way with the standard library.