### PR TITLE
No colon when setting empty password

### DIFF
--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -269,7 +269,7 @@ fn ends_in_a_number(input: &str) -> bool {
     } else {
         last
     };
-    if !last.is_empty() && last.chars().all(|c| ('0'..='9').contains(&c)) {
+    if !last.is_empty() && last.chars().all(|c| c.is_ascii_digit()) {
         return true;
     }
 
@@ -298,10 +298,8 @@ fn parse_ipv4number(mut input: &str) -> Result<Option<u32>, ()> {
 
     let valid_number = match r {
         8 => input.chars().all(|c| ('0'..='7').contains(&c)),
-        10 => input.chars().all(|c| ('0'..='9').contains(&c)),
-        16 => input.chars().all(|c| {
-            ('0'..='9').contains(&c) || ('a'..='f').contains(&c) || ('A'..='F').contains(&c)
-        }),
+        10 => input.chars().all(|c| c.is_ascii_digit()),
+        16 => input.chars().all(|c| c.is_ascii_hexdigit()),
         _ => false,
     };
     if !valid_number {

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -269,7 +269,7 @@ fn ends_in_a_number(input: &str) -> bool {
     } else {
         last
     };
-    if !last.is_empty() && last.chars().all(|c| c.is_ascii_digit()) {
+    if !last.is_empty() && last.as_bytes().iter().all(|c| c.is_ascii_digit()) {
         return true;
     }
 
@@ -297,9 +297,9 @@ fn parse_ipv4number(mut input: &str) -> Result<Option<u32>, ()> {
     }
 
     let valid_number = match r {
-        8 => input.chars().all(|c| ('0'..='7').contains(&c)),
-        10 => input.chars().all(|c| c.is_ascii_digit()),
-        16 => input.chars().all(|c| c.is_ascii_hexdigit()),
+        8 => input.as_bytes().iter().all(|c| (b'0'..=b'7').contains(c)),
+        10 => input.as_bytes().iter().all(|c| c.is_ascii_digit()),
+        16 => input.as_bytes().iter().all(|c| c.is_ascii_hexdigit()),
         _ => false,
     };
     if !valid_number {

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2069,7 +2069,8 @@ impl Url {
         if !self.has_host() || self.host() == Some(Host::Domain("")) || self.scheme() == "file" {
             return Err(());
         }
-        if let Some(password) = password {
+        let password = password.unwrap_or_default();
+        if !password.is_empty() {
             let host_and_after = self.slice(self.host_start..).to_owned();
             self.serialization.truncate(self.username_end as usize);
             self.serialization.push(':');

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1517,7 +1517,7 @@ impl<'a> Parser<'a> {
             if c == '%' {
                 let mut input = input.clone();
                 if !matches!((input.next(), input.next()), (Some(a), Some(b))
-                             if is_ascii_hex_digit(a) && is_ascii_hex_digit(b))
+                             if a.is_ascii_hexdigit() && b.is_ascii_hexdigit())
                 {
                     vfn(SyntaxViolation::PercentDecode)
                 }
@@ -1526,11 +1526,6 @@ impl<'a> Parser<'a> {
             }
         }
     }
-}
-
-#[inline]
-fn is_ascii_hex_digit(c: char) -> bool {
-    matches!(c, 'a'..='f' | 'A'..='F' | '0'..='9')
 }
 
 // Non URL code points:

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -106,6 +106,17 @@ fn test_set_empty_hostname() {
     assert_eq!(base.as_str(), "moz:///baz");
 }
 
+#[test]
+fn test_set_empty_query() {
+    let mut base: Url = "moz://example.com/path?query".parse().unwrap();
+
+    base.set_query(Some(""));
+    assert_eq!(base.as_str(), "moz://example.com/path?");
+
+    base.set_query(None);
+    assert_eq!(base.as_str(), "moz://example.com/path");
+}
+
 macro_rules! assert_from_file_path {
     ($path: expr) => {
         assert_from_file_path!($path, $path)

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -65,6 +65,30 @@ fn test_set_empty_host() {
 }
 
 #[test]
+fn test_set_empty_username_and_password() {
+    let mut base: Url = "moz://foo:bar@servo/baz".parse().unwrap();
+    base.set_username("").unwrap();
+    assert_eq!(base.as_str(), "moz://:bar@servo/baz");
+
+    base.set_password(Some("")).unwrap();
+    assert_eq!(base.as_str(), "moz://:@servo/baz");
+
+    base.set_password(None).unwrap();
+    assert_eq!(base.as_str(), "moz://servo/baz");
+}
+
+#[test]
+fn test_set_empty_password() {
+    let mut base: Url = "moz://foo:bar@servo/baz".parse().unwrap();
+
+    base.set_password(Some("")).unwrap();
+    assert_eq!(base.as_str(), "moz://foo:@servo/baz");
+
+    base.set_password(None).unwrap();
+    assert_eq!(base.as_str(), "moz://foo@servo/baz");
+}
+
+#[test]
 fn test_set_empty_hostname() {
     use url::quirks;
     let mut base: Url = "moz://foo@servo/baz".parse().unwrap();

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -71,7 +71,7 @@ fn test_set_empty_username_and_password() {
     assert_eq!(base.as_str(), "moz://:bar@servo/baz");
 
     base.set_password(Some("")).unwrap();
-    assert_eq!(base.as_str(), "moz://:@servo/baz");
+    assert_eq!(base.as_str(), "moz://servo/baz");
 
     base.set_password(None).unwrap();
     assert_eq!(base.as_str(), "moz://servo/baz");
@@ -82,7 +82,7 @@ fn test_set_empty_password() {
     let mut base: Url = "moz://foo:bar@servo/baz".parse().unwrap();
 
     base.set_password(Some("")).unwrap();
-    assert_eq!(base.as_str(), "moz://foo:@servo/baz");
+    assert_eq!(base.as_str(), "moz://foo@servo/baz");
 
     base.set_password(None).unwrap();
     assert_eq!(base.as_str(), "moz://foo@servo/baz");


### PR DESCRIPTION
This addresses https://github.com/servo/rust-url/issues/796 by removing the colon (`:`) when setting the password to `Some("")`. According to the [URL Standard](https://url.spec.whatwg.org/#url-serializing):

> If url’s [password](https://url.spec.whatwg.org/#concept-url-password) is not the empty string, then append U+003A (:), followed by url’s [password](https://url.spec.whatwg.org/#concept-url-password), to output.

This cherry-picks https://github.com/servo/rust-url/pull/806 to add some tests for this.