### PR TITLE
Update msrv to 1.56 to keep up with serde-derive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.51.0, stable, beta, nightly]
+        rust: [1.56.0, stable, beta, nightly]
         exclude:
           - os: macos-latest
-            rust: 1.51.0
+            rust: 1.56.0
           - os: windows-latest
-            rust: 1.51.0
+            rust: 1.56.0
           - os: macos-latest
             rust: beta
           - os: windows-latest

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["parser-implementations", "web-programming", "encoding"]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.56"
 
 [badges]
 travis-ci = { repository = "servo/rust-url" }


### PR DESCRIPTION
The latest update of serde-derive increased its msvr to 1.56 causing our 1.51 CI to [fail](https://github.com/servo/rust-url/actions/runs/4454647785/jobs/7827117227#step:4:117).