### PR TITLE
Explicitly depend on serde_derive

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -31,10 +31,13 @@ debugger_test_parser = "0.1"
 form_urlencoded = { version = "1.1.0", path = "../form_urlencoded" }
 idna = { version = "0.3.0", path = "../idna" }
 percent-encoding = { version = "2.2.0", path = "../percent_encoding" }
-serde = {version = "1.0", optional = true, features = ["derive"]}
+# Explicitly depend on serde_derive opposed to using the derive feature of serde to improve build times
+serde_derive = {version = "1.0", optional = true}
+serde = {version = "1.0", optional = true}
 
 [features]
 default = []
+serde = ["dep:serde", "dep:serde_derive"]
 # UNSTABLE FEATURES (requires Rust nightly)
 # Enable to use the #[debugger_visualizer] attribute.
 debugger_visualizer = []

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -12,7 +12,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use percent_encoding::{percent_decode, utf8_percent_encode, CONTROLS};
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::parser::{ParseError, ParseResult};
 


### PR DESCRIPTION
The `derive` feature of `serde` puts `serde` after `serde_derive` in the build graph which can hurt compile times. Depending on `serde_derive` explicitly avoids this, and as the change is rather non-invasive I figured this might be okay to submit.

see https://github.com/rust-lang/rust-analyzer/pull/14450