### PR TITLE
Compile with serde feature on Rust playground and docs.rs

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -51,3 +51,9 @@ name = "debugger_visualizer"
 path = "tests/debugger_visualizer.rs"
 required-features = ["debugger_visualizer"]
 test = false
+
+[package.metadata.docs.rs]
+features = ["serde"]
+
+[package.metadata.playground]
+features = ["serde"]


### PR DESCRIPTION
This will allow using `Url`'s serde impls in the Rust playground (https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b581a8494125e2fd6284ee9650bc32ef).