### PR TITLE
Resolves #844 by returning `Ok(())` if username or password is empty

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2088,6 +2088,9 @@ impl Url {
     pub fn set_password(&mut self, password: Option<&str>) -> Result<(), ()> {
         // has_host implies !cannot_be_a_base
         if !self.has_host() || self.host() == Some(Host::Domain("")) || self.scheme() == "file" {
+            if password.is_none() || password == Some("") {
+                return Ok(());
+            }
             return Err(());
         }
         let password = password.unwrap_or_default();
@@ -2182,6 +2185,9 @@ impl Url {
     pub fn set_username(&mut self, username: &str) -> Result<(), ()> {
         // has_host implies !cannot_be_a_base
         if !self.has_host() || self.host() == Some(Host::Domain("")) || self.scheme() == "file" {
+            if username.is_empty() {
+                return Ok(());
+            }
             return Err(());
         }
         let username_start = self.scheme_end + 3;


### PR DESCRIPTION
resolves #844 by checking for a value before returning `Err(())` in `set_username` and `set_password`.