### PR TITLE
Move debugger_visualizer tests to separate crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         if: |
           matrix.os == 'windows-latest' &&
           matrix.rust == 'nightly'
-        run: cargo test --test debugger_visualizer --features "url/serde,url/debugger_visualizer" -- --test-threads=1
+        run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1
       - name: Test `no_std` support
         run: cargo test --no-default-features --features=alloc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,9 @@
 [workspace]
-members = ["url", "form_urlencoded", "idna", "percent_encoding", "data-url"]
+members = [
+  "url",
+  "form_urlencoded",
+  "idna",
+  "percent_encoding",
+  "data-url",
+  "url_debug_tests",
+]

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -23,15 +23,12 @@ appveyor = { repository = "Manishearth/rust-url" }
 [dev-dependencies]
 serde_json = "1.0"
 bencher = "0.1"
-# To test debugger visualizers defined for the url crate such as url.natvis
-debugger_test = "0.1"
-debugger_test_parser = "0.1"
 
 [dependencies]
 form_urlencoded = { version = "1.2.0", path = "../form_urlencoded" }
 idna = { version = "0.4.0", path = "../idna" }
 percent-encoding = { version = "2.3.0", path = "../percent_encoding" }
-serde = {version = "1.0", optional = true, features = ["derive"]}
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
 default = []
@@ -45,12 +42,6 @@ expose_internals = []
 name = "parse_url"
 path = "benches/parse_url.rs"
 harness = false
-
-[[test]]
-name = "debugger_visualizer"
-path = "tests/debugger_visualizer.rs"
-required-features = ["debugger_visualizer"]
-test = false
 
 [package.metadata.docs.rs]
 features = ["serde"]

--- a/url_debug_tests/Cargo.toml
+++ b/url_debug_tests/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+
+name = "url_debug_tests"
+version = "0.0.0"
+description = "Tests for debugger visualizers defined for the url crate such as url.natvis"
+publish = false
+rust-version = "1.60"
+
+[dev-dependencies]
+url = { path = "../url" }
+debugger_test = "0.1"
+debugger_test_parser = "0.1"
+
+[features]
+debugger_visualizer = []
+
+[[test]]
+name = "debugger_visualizer"
+path = "tests/debugger_visualizer.rs"
+required-features = ["debugger_visualizer"]
+test = false

--- a/url_debug_tests/tests/debugger_visualizer.rs
+++ b/url_debug_tests/tests/debugger_visualizer.rs
@@ -1,3 +1,6 @@
+extern crate debugger_test;
+extern crate url;
+
 use debugger_test::debugger_test;
 use url::Url;
 


### PR DESCRIPTION
To prevent having to raise MSRV again, we move the debugger_visualizer
to a separate crate. This crate is only compiled when the feature
`debugger_visualizer` is enabled, because only then the
`debugger_visualizer` test is added as a compile target.

Implements @valenting's suggestion from #849
