### PR TITLE
Stabilize debugger_visualizer feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,12 @@ jobs:
         # Run tests enabling the serde feature
       - name: Run tests with the serde feature
         run: cargo test --features "url/serde,url/expose_internals"
-      # The #[debugger_visualizer] attribute is currently gated behind an unstable feature flag.
-      # In order to test the visualizers for the url crate, they have to be tested on a nightly build.
+      # The #[debugger_visualizer] attribute is currently gated behind a feature flag until #[debugger_visualizer]
+      # is available in all rustc versions past our MSRV. As such, we only run the tests on newer rustc versions.
       - name: Run debugger_visualizer tests
         if: |
           matrix.os == 'windows-latest' &&
-          matrix.rust == 'nightly'
+          matrix.rust != '1.56.0'
         run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1
       - name: Test `no_std` support
         run: cargo test --no-default-features --features=alloc

--- a/debug_metadata/README.md
+++ b/debug_metadata/README.md
@@ -22,8 +22,8 @@ types, descibe how to display those types. (For writing a pretty printer, see: h
 
 ### Embedding Visualizers
 
-Through the use of the currently unstable `#[debugger_visualizer]` attribute, the `url`
-crate can embed debugger visualizers into the crate metadata.
+Through the use of the `#[debugger_visualizer]` attribute, the `url` crate can embed
+debugger visualizers into the crate metadata.
 
 Currently the two types of visualizers supported are Natvis and Pretty printers.
 

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -28,8 +28,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
 default = []
-# UNSTABLE FEATURES (requires Rust nightly)
-# Enable to use the #[debugger_visualizer] attribute.
+# Enable to use the #[debugger_visualizer] attribute. This feature requires Rust >= 1.71.
 debugger_visualizer = []
 # Expose internal offsets of the URL.
 expose_internals = []

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -119,12 +119,24 @@ See [serde documentation](https://serde.rs) for more information.
 url = { version = "2", features = ["serde"] }
 ```
 
+# Feature: `debugger_visualizer`
+
+If you enable the `debugger_visualizer` feature, the `url` crate will include
+a [natvis file](https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects)
+for [Visual Studio](https://www.visualstudio.com/) that allows you to view
+[`Url`](struct.Url.html) objects in the debugger.
+
+This feature requires Rust 1.71 or later.
+
+```toml
+url = { version = "2", features = ["debugger_visualizer"] }
+```
+
 */
 
 #![doc(html_root_url = "https://docs.rs/url/2.4.0")]
 #![cfg_attr(
     feature = "debugger_visualizer",
-    feature(debugger_visualizer),
     debugger_visualizer(natvis_file = "../../debug_metadata/url.natvis")
 )]
 


### PR DESCRIPTION
Rust 1.71 stabilizes tomorrow (13-Jul-2023).

Closes #854