### PR TITLE
Implement std::error::Error for InvalidBase64

### DIFF
--- a/data-url/src/forgiving_base64.rs
+++ b/data-url/src/forgiving_base64.rs
@@ -21,6 +21,9 @@ impl fmt::Display for InvalidBase64 {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidBase64 {}
+
 #[derive(Debug)]
 enum InvalidBase64Details {
     UnexpectedSymbol(u8),


### PR DESCRIPTION
Small followup to #698 (towards #697)