### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -26,3 +26,6 @@ test = false
 [[test]]
 name = "wpt"
 harness = false
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -19,3 +19,6 @@ alloc = ["percent-encoding/alloc"]
 
 [dependencies]
 percent-encoding = { version = "2.3.0", default-features = false, path = "../percent_encoding" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -38,3 +38,6 @@ unicode-normalization = { version = "0.1.22", default-features = false }
 [[bench]]
 name = "all"
 harness = false
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -13,3 +13,6 @@ rust-version = "1.51"
 default = ["std"]
 std = ["alloc"]
 alloc = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -41,6 +41,7 @@ harness = false
 
 [package.metadata.docs.rs]
 features = ["serde"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.playground]
 features = ["serde"]


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).