### PR TITLE
Compile serde_derive separately from serde

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 rust-version = "1.56"
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde_crate = { package = "serde", version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bencher = "0.1"
 
@@ -25,7 +25,8 @@ bencher = "0.1"
 form_urlencoded = { version = "1.2.0", path = "../form_urlencoded" }
 idna = { version = "0.4.0", path = "../idna" }
 percent-encoding = { version = "2.3.0", path = "../percent_encoding" }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_crate = { package = "serde", version = "1.0.186", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 [features]
 default = []
@@ -33,6 +34,7 @@ default = []
 debugger_visualizer = []
 # Expose internal offsets of the URL.
 expose_internals = []
+serde = ["serde_crate", "serde_derive"]
 
 [[test]]
 name = "url_wpt"

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -12,11 +12,15 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use percent_encoding::{percent_decode, utf8_percent_encode, CONTROLS};
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::parser::{ParseError, ParseResult};
 
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Deserialize, Serialize),
+    serde(crate = "serde"),
+)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum HostInternal {
     None,
@@ -37,7 +41,11 @@ impl From<Host<String>> for HostInternal {
 }
 
 /// The host name of an URL.
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Deserialize, Serialize),
+    serde(crate = "serde"),
+)]
 #[derive(Clone, Debug, Eq, Ord, PartialOrd, Hash)]
 pub enum Host<S = String> {
     /// A DNS domain name, as '.' dot-separated labels.

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -143,7 +143,7 @@ url = { version = "2", features = ["debugger_visualizer"] }
 pub use form_urlencoded;
 
 #[cfg(feature = "serde")]
-extern crate serde;
+extern crate serde_crate as serde;
 
 use crate::host::HostInternal;
 use crate::parser::{to_u32, Context, Parser, SchemeType, PATH_SEGMENT, USERINFO};

--- a/url/tests/wpt.rs
+++ b/url/tests/wpt.rs
@@ -8,6 +8,8 @@
 
 //! Data-driven tests imported from web-platform-tests
 
+extern crate serde_crate as serde;
+
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::panic;
@@ -16,6 +18,7 @@ use serde_json::Value;
 use url::Url;
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(crate = "serde")]
 struct UrlTest {
     input: String,
     base: Option<String>,
@@ -24,7 +27,7 @@ struct UrlTest {
 }
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(untagged)]
+#[serde(crate = "serde", untagged)]
 #[allow(clippy::large_enum_variant)]
 enum UrlTestResult {
     Ok(UrlTestOk),
@@ -32,6 +35,7 @@ enum UrlTestResult {
 }
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(crate = "serde")]
 struct UrlTestOk {
     href: String,
     protocol: String,
@@ -46,11 +50,13 @@ struct UrlTestOk {
 }
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(crate = "serde")]
 struct UrlTestFail {
     failure: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(crate = "serde")]
 struct SetterTest {
     href: String,
     new_value: String,
@@ -58,6 +64,7 @@ struct SetterTest {
 }
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(crate = "serde")]
 struct SetterTestExpected {
     href: Option<String>,
     protocol: Option<String>,


### PR DESCRIPTION
When `serde`'s `derive` feature is used, `serde_derive` must be compiled before `serde` can be, as `serde` with that feature has a `serde_derive` dependency.

As of serde 1.0.186, this issue can be avoided by adding a separate `serde_derive` dependency due to the fact that serde 1.0.186 has a never-applicable dependency on `serde_derive`, which ensures that there is no incompatible version of `serde_derive` in a program (https://github.com/serde-rs/serde/pull/2588).

Because MSRV being set to 1.56, it's not possible to use the `dep:` syntax in features, so `serde` crate needs to be renamed. `dep:` syntax was added in Rust 1.60 if we want to bump MSRV.

This should improve compilation times of programs that use `url` with its `serde` feature, provided it doesn't have other crates that use `serde` with its `derive` feature.