### PR TITLE
Correct spelling mistake in `Position` docs

### DIFF
--- a/url/src/slicing.rs
+++ b/url/src/slicing.rs
@@ -93,7 +93,7 @@ fn test_count_digits() {
 ///
 /// The end of a component and the start of the next are either the same or separate
 /// by a delimiter.
-/// (Not that the initial `/` of a path is considered part of the path here, not a delimiter.)
+/// (Note that the initial `/` of a path is considered part of the path here, not a delimiter.)
 /// For example, `&url[..BeforeFragment]` would include a `#` delimiter (if present in `url`),
 /// so `&url[..AfterQuery]` might be desired instead.
 ///


### PR DESCRIPTION
The sentence in question was clearly intended to remark that the leading slash in the path is part of said path, but due to the missing "e" at the end of "Note", it (ungrammatically) says the opposite.