### PR TITLE
Added #[must_use] Attributes for Configuration Options

### DIFF
--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -509,6 +509,7 @@ impl Idna {
 }
 
 #[derive(Clone, Copy)]
+#[must_use]
 pub struct Config {
     use_std3_ascii_rules: bool,
     transitional_processing: bool,

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -205,6 +205,7 @@ pub struct Url {
 
 /// Full configuration for the URL parser.
 #[derive(Copy, Clone)]
+#[must_use]
 pub struct ParseOptions<'a> {
     base_url: Option<&'a Url>,
     encoding_override: EncodingOverride<'a>,


### PR DESCRIPTION
Resolves issues similar to https://github.com/Redfire75369/spiderfire/pull/35, where the updated `ParseOptions` isn't used since it is `Copy`.