### PR TITLE
Add UniFFI support impl FfiConverter for Url - gated behind `uniffi` feature flag.

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -20,12 +20,14 @@ rust-version = "1.56"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bencher = "0.1"
+uniffi = "0.25"
 
 [dependencies]
 form_urlencoded = { version = "1.2.1", path = "../form_urlencoded" }
 idna = { version = "0.5.0", path = "../idna" }
 percent-encoding = { version = "2.3.1", path = "../percent_encoding" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+uniffi_core = { optional = true, version = "0.25", default-features = false }
 
 [features]
 default = []
@@ -33,6 +35,7 @@ default = []
 debugger_visualizer = []
 # Expose internal offsets of the URL.
 expose_internals = []
+uniffi = ["uniffi_core"]
 
 [[test]]
 name = "url_wpt"

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -3056,10 +3056,7 @@ mod uniffi_core_impl {
 
     use super::*;
 
-    use uniffi_core::{
-        deps::bytes::{Buf, BufMut},
-        metadata, FfiConverter, MetadataBuffer,
-    };
+    use uniffi_core::{metadata, FfiConverter, MetadataBuffer};
 
     uniffi_core::derive_ffi_traits!(blanket Url);
 
@@ -3077,7 +3074,10 @@ mod uniffi_core_impl {
         }
 
         const TYPE_ID_META: MetadataBuffer =
-            MetadataBuffer::from_code(metadata::codes::TYPE_STRING);
+            MetadataBuffer::from_code(metadata::codes::TYPE_CUSTOM)
+                .concat_str("url::Url")
+                .concat_str("Url")
+                .concat(<String as uniffi_core::Lower<String>>::TYPE_ID_META);
     }
 
     #[cfg(test)]


### PR DESCRIPTION
As [UniFFI](https://github.com/mozilla/uniffi-rs) gathers support, it would be convenient for Url to be able to be used with UniFFI!

Inspired by @novacrazy's work in https://github.com/Lantern-chat/iso8601-timestamp/pull/8 credits goes to Nova!

However, as pointed out by @mhammond at UniFFI users can instead of using this feature flag (part of Url) do it "manually" in their own project like so:

https://github.com/mozilla/uniffi-rs/blob/main/examples/custom-types/src/lib.rs#L36-L47

So might not be worth merging.