### PR TITLE
perf(punycode): avoid double allocation in decode_to_string

### DIFF
--- a/idna/src/punycode.rs
+++ b/idna/src/punycode.rs
@@ -41,10 +41,12 @@ fn adapt(mut delta: u32, num_points: u32, first_time: bool) -> u32 {
 
 /// Convert Punycode to an Unicode `String`.
 ///
-/// This is a convenience wrapper around `decode`.
+/// Return None on malformed input or overflow.
+/// Overflow can only happen on inputs that take more than
+/// 63 encoded bytes, the DNS limit on domain name labels.
 #[inline]
 pub fn decode_to_string(input: &str) -> Option<String> {
-    decode(input).map(|chars| chars.into_iter().collect())
+    Some(Decoder::default().decode(input).ok()?.collect())
 }
 
 /// Convert Punycode to Unicode.

--- a/idna/tests/punycode.rs
+++ b/idna/tests/punycode.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::test::TestFn;
-use idna::punycode::{decode, encode_str};
+use idna::punycode::{decode, decode_to_string, encode_str};
 use serde_json::map::Map;
 use serde_json::Value;
 use std::panic::catch_unwind;
@@ -26,6 +26,17 @@ fn one_test(decoded: &str, encoded: &str) {
                 decoded
             )
         }
+    }
+
+    match decode_to_string(encoded) {
+        None => panic!("Decoding {} failed.", encoded),
+        Some(result) => assert!(
+            result == decoded,
+            "Incorrect decoding of \"{}\":\n   \"{}\"\n!= \"{}\"\n",
+            encoded,
+            result,
+            decoded
+        ),
     }
 
     match encode_str(decoded) {


### PR DESCRIPTION
Hey,
while indeed `decode_to_string` is a nice ergonomics addition, the fact of being a wrapper over the `decode` results in an intermediate `Vec`.
Since the implementation of it can be the same as `decode` and it's quite straightforward, maybe we could get rid of double alloc cheaply