### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
This transition is due to a decision made by the Servo TSC several months ago. We are standardizing on the shorter and friendlier 'main' as the branch name for all active repositories.