### PR TITLE
Fix lint

### DIFF
--- a/form_urlencoded/src/lib.rs
+++ b/form_urlencoded/src/lib.rs
@@ -396,6 +396,9 @@ pub(crate) fn encode<'a>(encoding_override: EncodingOverride<'_>, input: &'a str
     input.as_bytes().into()
 }
 
+// std::ptr::addr_eq was stabilized in rust 1.76. Once we upgrade
+// the MSRV we can remove this lint override.
+#[allow(ambiguous_wide_pointer_comparisons)]
 pub(crate) fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     // Note: This function is duplicated in `percent_encoding/lib.rs`.
     match input {

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -447,6 +447,9 @@ impl<'a> PercentDecode<'a> {
     }
 }
 
+// std::ptr::addr_eq was stabilized in rust 1.76. Once we upgrade
+// the MSRV we can remove this lint override.
+#[allow(ambiguous_wide_pointer_comparisons)]
 #[cfg(feature = "alloc")]
 fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     // Note: This function is duplicated in `form_urlencoded/src/query_encoding.rs`.


### PR DESCRIPTION
The clippy suggestion was to use std::ptr::addr_eq, but that got stabilized in 1.76
In order to avoid breaking our 1.56 builds, we just allow this for now.