### PR TITLE
Non-special URLs can have their paths erased

### DIFF
--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -279,10 +279,15 @@ pub fn set_pathname(url: &mut Url, new_pathname: &str) {
             && new_pathname.starts_with('\\'))
     {
         url.set_path(new_pathname)
-    } else {
+    } else if SchemeType::from(url.scheme()).is_special()
+        || !new_pathname.is_empty()
+        || !url.has_host()
+    {
         let mut path_to_set = String::from("/");
         path_to_set.push_str(new_pathname);
         url.set_path(&path_to_set)
+    } else {
+        url.set_path(new_pathname)
     }
 }
 

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -38,7 +38,6 @@
 <http://example.net:8080/path> set hostname to <example.com:>
 <non-spec:/.//p> set hostname to <h>
 <non-spec:/.//p> set hostname to <>
-<foo://somehost/some/path> set pathname to <>
 <foo:///some/path> set pathname to <>
 <http://example.net:8080/path> set port to <randomstring>
 <file:///var/log/system.log> set href to <http://0300.168.0xF0>


### PR DESCRIPTION
For Bug [1874117](https://bugzilla.mozilla.org/show_bug.cgi?id=1874117) with reviewer @valenting

Sorry, I accidentally closed the first [PR ](https://github.com/servo/rust-url/pull/919)