### PR TITLE
Adjust Punycode overflow checks

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idna"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["The rust-url developers"]
 description = "IDNA (Internationalizing Domain Names in Applications) and Punycode."
 categories = ["no_std"]


### PR DESCRIPTION
* The change made in 1.0.0 incorrectly assumed that the input length limit removed the need to do overflow check when decoding. Now the internal-caller length limit is taken as a permission to skip overflow checks only when encoding.
* The RFC gives overflow checking pre-flight math for languages like that don't have checked math. Since Rust does, the code now uses checked_add and checked_mul instead of pre-flight when overflow checks are performed.