### PR TITLE
Support url parsing at compile-time via proc-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
 members = [
-  "url",
-  "form_urlencoded",
-  "idna",
-  "percent_encoding",
-  "data-url",
-  "url_debug_tests",
+    "url",
+    "form_urlencoded",
+    "idna",
+    "percent_encoding",
+    "data-url",
+    "url_debug_tests",
+    "url-macro",
 ]

--- a/url-macro/Cargo.toml
+++ b/url-macro/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "url-macro"
+version = "0.1.0"
+edition = "2018"
+rust-version = "1.56"
+
+authors = ["The rust-url developers"]
+description = "URL library for Rust, based on the WHATWG URL Standard"
+documentation = "https://docs.rs/url"
+repository = "https://github.com/servo/rust-url"
+readme = "../README.md"
+keywords = ["url", "parser"]
+categories = ["parser-implementations", "web-programming", "encoding"]
+license = "MIT OR Apache-2.0"
+
+include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
+
+[dependencies]

--- a/url-macro/Cargo.toml
+++ b/url-macro/Cargo.toml
@@ -15,4 +15,16 @@ license = "MIT OR Apache-2.0"
 
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 
+[lib]
+proc-macro = true
+
 [dependencies]
+url = { version = "2.5.2", path = "../url", default-features = false, features = [
+    "expose_internals",
+] }
+proc-macro2 = "1.0.68"
+syn = { version = "2.0.43", default-features = false, features = [
+    "proc-macro",
+    "parsing",
+] }
+quote = "1.0.28"

--- a/url-macro/LICENSE-APACHE
+++ b/url-macro/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/url-macro/LICENSE-MIT
+++ b/url-macro/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2013-2022 The rust-url developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/url-macro/src/lib.rs
+++ b/url-macro/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/url-macro/src/lib.rs
+++ b/url-macro/src/lib.rs
@@ -1,14 +1,74 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, LitStr};
+use url::{
+    quirks::{internal_components, InternalComponents},
+    Host, Url,
+};
+
+fn quote_option<T: ToTokens>(value: Option<T>) -> proc_macro2::TokenStream {
+    if let Some(value) = value {
+        quote! { ::core::option::Option::Some(#value) }
+    } else {
+        quote! { ::core::option::Option::None }
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Parse url at compile-time
+///
+/// ```
+/// const URL: url::Url = url_macro::parse!("https://www.github.com");
+/// # fn main() {
+/// assert_eq!(URL, url::Url::parse("https://www.github.com").unwrap());
+/// # }
+/// ```
+#[proc_macro]
+pub fn parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as LitStr).value();
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    let url = Url::parse(&input).unwrap();
+
+    let serialization = url.as_str();
+    let host = match url.host().unwrap_or(Host::Domain("")) {
+        Host::Ipv4(address) => {
+            let octets = &address.octets();
+            quote! { ::url::Host::Ipv4(::std::net::Ipv4Addr::new(#(#octets),*)) }
+        }
+        Host::Ipv6(address) => {
+            let octets = &address.octets();
+            quote! { ::url::Host::Ipv6(::std::net::Ipv6Addr::new(#(#octets),*)) }
+        }
+        Host::Domain(domain) => quote! { ::url::Host::Domain(#domain) },
+    };
+    let InternalComponents {
+        scheme_end,
+        username_end,
+        host_start,
+        host_end,
+        path_start,
+        port,
+        query_start,
+        fragment_start,
+    } = internal_components(&url);
+
+    let port = quote_option(port);
+    let query_start = quote_option(query_start);
+    let fragment_start = quote_option(fragment_start);
+
+    quote! {
+        ::url::quirks::url_from_parts(
+            #serialization,
+            #host,
+            ::url::quirks::InternalComponents {
+                scheme_end: #scheme_end,
+                username_end: #username_end,
+                host_start: #host_start,
+                host_end: #host_end,
+                path_start: #path_start,
+                port: #port,
+                query_start: #query_start,
+                fragment_start: #fragment_start,
+            },
+        )
     }
+    .into()
 }

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -36,6 +36,23 @@ impl From<Host<String>> for HostInternal {
     }
 }
 
+impl Host<&'static str> {
+    pub(crate) const fn into_internal(self) -> HostInternal {
+        match self {
+            Host::Domain(s) if s.is_empty() => HostInternal::None,
+            Host::Domain(_) => HostInternal::Domain,
+            Host::Ipv4(address) => HostInternal::Ipv4(address),
+            Host::Ipv6(address) => HostInternal::Ipv6(address),
+        }
+    }
+}
+
+impl From<Host<&'static str>> for HostInternal {
+    fn from(host: Host<&'static str>) -> HostInternal {
+        host.into_internal()
+    }
+}
+
 /// The host name of an URL.
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, Eq, Ord, PartialOrd, Hash)]

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -366,7 +366,7 @@ impl Url {
 
         let start = self.serialization.len() - trailing_space_count;
 
-        self.serialization.to_mut().truncate(start);
+        self.truncate(start);
     }
 
     /// Parse a string as an URL, with this URL as the base URL.
@@ -1548,7 +1548,7 @@ impl Url {
         self.fragment_start.take().map(|start| {
             debug_assert!(self.byte_at(start) == b'#');
             let fragment = self.slice(start + 1..).to_owned();
-            self.serialization.to_mut().truncate(start as usize);
+            self.truncate(start as usize);
             fragment
         })
     }

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::{self, Formatter, Write};
 use std::str;
@@ -539,7 +540,7 @@ impl<'a> Parser<'a> {
                 let (query_start, fragment_start) =
                     self.parse_query_and_fragment(scheme_type, scheme_end, remaining)?;
                 return Ok(Url {
-                    serialization: self.serialization,
+                    serialization: Cow::Owned(self.serialization),
                     scheme_end,
                     username_end: host_start,
                     host_start,
@@ -590,7 +591,7 @@ impl<'a> Parser<'a> {
 
                 let host_end = host_end as u32;
                 return Ok(Url {
-                    serialization: self.serialization,
+                    serialization: Cow::Owned(self.serialization),
                     scheme_end,
                     username_end: host_start,
                     host_start,
@@ -613,7 +614,7 @@ impl<'a> Parser<'a> {
                     };
                     self.serialization.push_str(before_fragment);
                     Ok(Url {
-                        serialization: self.serialization,
+                        serialization: Cow::Owned(self.serialization),
                         fragment_start: None,
                         ..*base_url
                     })
@@ -628,7 +629,7 @@ impl<'a> Parser<'a> {
                     let (query_start, fragment_start) =
                         self.parse_query_and_fragment(scheme_type, base_url.scheme_end, input)?;
                     Ok(Url {
-                        serialization: self.serialization,
+                        serialization: Cow::Owned(self.serialization),
                         query_start,
                         fragment_start,
                         ..*base_url
@@ -670,7 +671,7 @@ impl<'a> Parser<'a> {
                             self.parse_query_and_fragment(SchemeType::File, scheme_end, remaining)?;
                         let path_start = path_start as u32;
                         Ok(Url {
-                            serialization: self.serialization,
+                            serialization: Cow::Owned(self.serialization),
                             scheme_end,
                             username_end: path_start,
                             host_start: path_start,
@@ -693,7 +694,7 @@ impl<'a> Parser<'a> {
                 self.parse_query_and_fragment(SchemeType::File, scheme_end, remaining)?;
             let path_start = path_start as u32;
             Ok(Url {
-                serialization: self.serialization,
+                serialization: Cow::Owned(self.serialization),
                 scheme_end,
                 username_end: path_start,
                 host_start: path_start,
@@ -725,7 +726,7 @@ impl<'a> Parser<'a> {
                 };
                 self.serialization.push_str(before_fragment);
                 Ok(Url {
-                    serialization: self.serialization,
+                    serialization: Cow::Owned(self.serialization),
                     fragment_start: None,
                     ..*base_url
                 })
@@ -740,7 +741,7 @@ impl<'a> Parser<'a> {
                 let (query_start, fragment_start) =
                     self.parse_query_and_fragment(scheme_type, base_url.scheme_end, input)?;
                 Ok(Url {
-                    serialization: self.serialization,
+                    serialization: Cow::Owned(self.serialization),
                     query_start,
                     fragment_start,
                     ..*base_url
@@ -1416,7 +1417,7 @@ impl<'a> Parser<'a> {
         let (query_start, fragment_start) =
             self.parse_query_and_fragment(scheme_type, scheme_end, remaining)?;
         Ok(Url {
-            serialization: self.serialization,
+            serialization: Cow::Owned(self.serialization),
             scheme_end,
             username_end,
             host_start,
@@ -1510,7 +1511,7 @@ impl<'a> Parser<'a> {
         debug_assert!(next == Some('#'));
         self.parse_fragment(input);
         Ok(Url {
-            serialization: self.serialization,
+            serialization: Cow::Owned(self.serialization),
             fragment_start: Some(to_u32(before_fragment.len())?),
             ..*base_url
         })

--- a/url/src/path_segments.rs
+++ b/url/src/path_segments.rs
@@ -90,7 +90,7 @@ impl<'a> PathSegmentsMut<'a> {
     /// # run().unwrap();
     /// ```
     pub fn clear(&mut self) -> &mut Self {
-        self.url.serialization.truncate(self.after_first_slash);
+        self.url.truncate(self.after_first_slash);
         self
     }
 
@@ -127,7 +127,7 @@ impl<'a> PathSegmentsMut<'a> {
             return self;
         }
         if self.url.serialization[self.after_first_slash..].ends_with('/') {
-            self.url.serialization.pop();
+            self.url.serialization.to_mut().pop();
         }
         self
     }
@@ -144,9 +144,7 @@ impl<'a> PathSegmentsMut<'a> {
         let last_slash = self.url.serialization[self.after_first_slash..]
             .rfind('/')
             .unwrap_or(0);
-        self.url
-            .serialization
-            .truncate(self.after_first_slash + last_slash);
+        self.url.truncate(self.after_first_slash + last_slash);
         self
     }
 

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -11,8 +11,48 @@
 //! Unless you need to be interoperable with web browsers,
 //! you probably want to use `Url` method instead.
 
+use std::borrow::Cow;
+
 use crate::parser::{default_port, Context, Input, Parser, SchemeType};
 use crate::{Host, ParseError, Position, Url};
+
+pub struct UrlInternal {
+    pub serialization: &'static str,
+    pub host: Host<&'static str>,
+    pub components: InternalComponents,
+}
+
+#[doc(hidden)]
+pub const fn url_from_parts(
+    UrlInternal {
+        serialization,
+        host,
+        components:
+            InternalComponents {
+                scheme_end,
+                username_end,
+                host_start,
+                host_end,
+                port,
+                path_start,
+                query_start,
+                fragment_start,
+            },
+    }: UrlInternal,
+) -> Url {
+    Url {
+        serialization: Cow::Borrowed(serialization),
+        scheme_end,
+        username_end,
+        host_start,
+        host_end,
+        host: host.into_internal(),
+        port,
+        path_start,
+        query_start,
+        fragment_start,
+    }
+}
 
 /// Internal components / offsets of a URL.
 ///

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -16,29 +16,19 @@ use std::borrow::Cow;
 use crate::parser::{default_port, Context, Input, Parser, SchemeType};
 use crate::{Host, ParseError, Position, Url};
 
-pub struct UrlInternal {
-    pub serialization: &'static str,
-    pub host: Host<&'static str>,
-    pub components: InternalComponents,
-}
-
-#[doc(hidden)]
 pub const fn url_from_parts(
-    UrlInternal {
-        serialization,
-        host,
-        components:
-            InternalComponents {
-                scheme_end,
-                username_end,
-                host_start,
-                host_end,
-                port,
-                path_start,
-                query_start,
-                fragment_start,
-            },
-    }: UrlInternal,
+    serialization: &'static str,
+    host: Host<&'static str>,
+    InternalComponents {
+        scheme_end,
+        username_end,
+        host_start,
+        host_end,
+        port,
+        path_start,
+        query_start,
+        fragment_start,
+    }: InternalComponents,
 ) -> Url {
     Url {
         serialization: Cow::Borrowed(serialization),

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -57,7 +57,6 @@ pub const fn url_from_parts(
 ///      |      `--------------------------------------- username_end
 ///      `---------------------------------------------- scheme_end
 #[derive(Copy, Clone)]
-#[cfg(feature = "expose_internals")]
 pub struct InternalComponents {
     pub scheme_end: u32,
     pub username_end: u32,
@@ -73,7 +72,6 @@ pub struct InternalComponents {
 ///
 /// This can be useful for implementing efficient serialization
 /// for the URL.
-#[cfg(feature = "expose_internals")]
 pub fn internal_components(url: &Url) -> InternalComponents {
     InternalComponents {
         scheme_end: url.scheme_end,


### PR DESCRIPTION
Added new crate `url_macro`, usage:

```rust
const URL: url::Url = url_macro::parse!("https://www.github.com");
assert_eq!(URL, url::Url::parse("https://www.github.com").unwrap());
```

# Motivation

It is not uncommon for users to want to parse `Url` at compile time, instead of having to use `OnceCell`/`OnceLock`, it would be more ergonomic/efficient to parse it at compile-time.