### PR TITLE
`no_std` support for the `url` crate with no breaking changes for feature `std`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      # Add toolchain for no_std tests
+      - run: rustup toolchain install nightly
+      - name: Add `aarch64-unknown-none` toolchain for `no_std` tests
+        if: |
+          matrix.os == 'ubuntu-latest' &&
+          matrix.rust == 'nightly'
+        run: rustup target add aarch64-unknown-none && rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
       - run: cargo build --all-targets
         # Run tests
       - name: Run tests
@@ -51,6 +58,13 @@ jobs:
         run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1
       - name: Test `no_std` support
         run: cargo test --no-default-features --features=alloc
+      - name: Build `url` crate for `aarch64-unknown-none` with `no_std`
+        if: |
+          matrix.os == 'ubuntu-latest' &&
+          matrix.rust == 'nightly'
+        run: >
+          cd url
+          && cargo +nightly check -Zbuild-std=core,alloc --target aarch64-unknown-none -v --release --no-default-features --features=alloc
 
   WASM:
     runs-on: ubuntu-latest

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/url"
 repository = "https://github.com/servo/rust-url"
 readme = "../README.md"
 keywords = ["url", "parser"]
-categories = ["parser-implementations", "web-programming", "encoding"]
+categories = ["parser-implementations", "web-programming", "encoding", "no_std"]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
@@ -25,13 +25,15 @@ bencher = "0.1"
 wasm-bindgen-test = "0.3"
 
 [dependencies]
-form_urlencoded = { version = "1.2.1", path = "../form_urlencoded" }
-idna = { version = "0.5.0", path = "../idna" }
-percent-encoding = { version = "2.3.1", path = "../percent_encoding" }
+form_urlencoded = { version = "1.2.1", path = "../form_urlencoded", default-features = false }
+idna = { version = "0.5.0", path = "../idna", default-features = false }
+percent-encoding = { version = "2.3.1", path = "../percent_encoding", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
-default = []
+default = ["std"]
+std = ["alloc", "form_urlencoded/std", "idna/std", "percent-encoding/std"]
+alloc = ["form_urlencoded/alloc", "idna/alloc", "percent-encoding/alloc"]
 # Enable to use the #[debugger_visualizer] attribute. This feature requires Rust >= 1.71.
 debugger_visualizer = []
 # Expose internal offsets of the URL.

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -6,9 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::cmp;
-use std::fmt::{self, Formatter};
-use std::net::{Ipv4Addr, Ipv6Addr};
+use core::cmp;
+use core::fmt::{self, Formatter};
+use std_core_compat::net::{Ipv4Addr, Ipv6Addr};
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 use percent_encoding::{percent_decode, utf8_percent_encode, CONTROLS};
 #[cfg(feature = "serde")]

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -6,13 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::cmp;
-use core::fmt::{self, Formatter};
-use std_core_compat::net::{Ipv4Addr, Ipv6Addr};
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
+use core::cmp;
+use core::fmt::{self, Formatter};
+use std_core_compat::net::{Ipv4Addr, Ipv6Addr};
 
 use percent_encoding::{percent_decode, utf8_percent_encode, CONTROLS};
 #[cfg(feature = "serde")]

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -164,15 +164,15 @@ use crate::host::HostInternal;
 use crate::parser::{
     to_u32, Context, Parser, SchemeType, PATH_SEGMENT, SPECIAL_PATH_SEGMENT, USERINFO,
 };
-use percent_encoding::{percent_decode, percent_encode, utf8_percent_encode};
 use core::borrow::Borrow;
 use core::cmp;
 use core::fmt::{self, Write};
 use core::hash;
 use core::mem;
-use std_core_compat::net::IpAddr;
 use core::ops::{Range, RangeFrom, RangeTo};
 use core::str;
+use percent_encoding::{percent_decode, percent_encode, utf8_percent_encode};
+use std_core_compat::net::IpAddr;
 
 use alloc::borrow::ToOwned;
 use alloc::format;
@@ -1291,13 +1291,16 @@ impl Url {
     ///     })
     /// }
     /// ```
-    #[cfg(all(feature = "std", any(unix, windows, target_os = "redox", target_os = "wasi")))]
+    #[cfg(all(
+        feature = "std",
+        any(unix, windows, target_os = "redox", target_os = "wasi")
+    ))]
     pub fn socket_addrs(
         &self,
         default_port_number: impl Fn() -> Option<u16>,
     ) -> std::io::Result<Vec<std::net::SocketAddr>> {
-        use std::net::ToSocketAddrs;
         use std::io;
+        use std::net::ToSocketAddrs;
         // Note: trying to avoid the Vec allocation by returning `impl AsRef<[SocketAddr]>`
         // causes borrowck issues because the return value borrows `default_port_number`:
         //
@@ -2483,7 +2486,10 @@ impl Url {
     /// # run().unwrap();
     /// # }
     /// ```
-    #[cfg(all(feature = "std", any(unix, windows, target_os = "redox", target_os = "wasi")))]
+    #[cfg(all(
+        feature = "std",
+        any(unix, windows, target_os = "redox", target_os = "wasi")
+    ))]
     #[allow(clippy::result_unit_err)]
     pub fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, ()> {
         let mut serialization = "file://".to_owned();
@@ -2520,7 +2526,10 @@ impl Url {
     ///
     /// Note that `std::path` does not consider trailing slashes significant
     /// and usually does not include them (e.g. in `Path::parent()`).
-    #[cfg(all(feature = "std", any(unix, windows, target_os = "redox", target_os = "wasi")))]
+    #[cfg(all(
+        feature = "std",
+        any(unix, windows, target_os = "redox", target_os = "wasi")
+    ))]
     #[allow(clippy::result_unit_err)]
     pub fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, ()> {
         let mut url = Url::from_file_path(path)?;
@@ -2637,7 +2646,10 @@ impl Url {
     /// (That is, if the percent-decoded path contains a NUL byte or,
     /// for a Windows path, is not UTF-8.)
     #[inline]
-    #[cfg(all(feature = "std", any(unix, windows, target_os = "redox", target_os = "wasi")))]
+    #[cfg(all(
+        feature = "std",
+        any(unix, windows, target_os = "redox", target_os = "wasi")
+    ))]
     #[allow(clippy::result_unit_err)]
     pub fn to_file_path(&self) -> Result<std::path::PathBuf, ()> {
         if let Some(segments) = self.path_segments() {
@@ -2950,11 +2962,11 @@ fn file_url_segments_to_pathbuf(
     segments: str::Split<'_, char>,
 ) -> Result<std::path::PathBuf, ()> {
     use std::ffi::OsStr;
-    use std::path::PathBuf;
     #[cfg(any(unix, target_os = "redox"))]
     use std::os::unix::prelude::OsStrExt;
     #[cfg(target_os = "wasi")]
     use std::os::wasi::prelude::OsStrExt;
+    use std::path::PathBuf;
 
     if host.is_some() {
         return Err(());

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -73,6 +73,14 @@ assert!(data_url.fragment() == Some(""));
 # run().unwrap();
 ```
 
+## Default Features
+
+Versions `< 3` of the crate have no default features. Versions `>= 3` have the default feature 'std'.
+If you are upgrading across this boundary and you have specified `default-features = false`, then
+you will need to add the 'std' feature or the 'alloc' feature to your dependency.
+The 'std' feature has the same behavior as the previous versions. The 'alloc' feature
+provides no_std support.
+
 ## Serde
 
 Enable the `serde` feature to include `Deserialize` and `Serialize` implementations for `url::Url`.

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -75,7 +75,7 @@ assert!(data_url.fragment() == Some(""));
 
 ## Default Features
 
-Versions `< 3` of the crate have no default features. Versions `>= 3` have the default feature 'std'.
+Versions `<= 2.5.2` of the crate have no default features. Versions `> 2.5.2` have the default feature 'std'.
 If you are upgrading across this boundary and you have specified `default-features = false`, then
 you will need to add the 'std' feature or the 'alloc' feature to your dependency.
 The 'std' feature has the same behavior as the previous versions. The 'alloc' feature

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2883,9 +2883,9 @@ fn path_to_file_url_segments(
     Ok((host_end, HostInternal::None))
 }
 
-#[cfg(windows)]
+#[cfg(all(feature = "std", windows))]
 fn path_to_file_url_segments(
-    path: &Path,
+    path: &std::path::Path,
     serialization: &mut String,
 ) -> Result<(u32, HostInternal), ()> {
     path_to_file_url_segments_windows(path, serialization)
@@ -3002,11 +3002,11 @@ fn file_url_segments_to_pathbuf(
     Ok(path)
 }
 
-#[cfg(windows)]
+#[cfg(all(feature = "std", windows))]
 fn file_url_segments_to_pathbuf(
     host: Option<&str>,
     segments: str::Split<char>,
-) -> Result<PathBuf, ()> {
+) -> Result<std::path::PathBuf, ()> {
     file_url_segments_to_pathbuf_windows(host, segments)
 }
 

--- a/url/src/origin.rs
+++ b/url/src/origin.rs
@@ -9,7 +9,10 @@
 use crate::host::Host;
 use crate::parser::default_port;
 use crate::Url;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::string::String;
 
 pub fn url_origin(url: &Url) -> Origin {
     let scheme = url.scheme();

--- a/url/src/origin.rs
+++ b/url/src/origin.rs
@@ -9,10 +9,10 @@
 use crate::host::Host;
 use crate::parser::default_port;
 use crate::Url;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use alloc::borrow::ToOwned;
 use alloc::format;
 use alloc::string::String;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 pub fn url_origin(url: &Url) -> Origin {
     let scheme = url.scheme();

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std_core_compat::error::Error;
-use core::fmt::{self, Formatter, Write};
-use core::str;
 use alloc::string::String;
 use alloc::string::ToString;
+use core::fmt::{self, Formatter, Write};
+use core::str;
+use std_core_compat::error::Error;
 
 use crate::host::{Host, HostInternal};
 use crate::Url;

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -6,9 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::error::Error;
-use std::fmt::{self, Formatter, Write};
-use std::str;
+use std_core_compat::error::Error;
+use core::fmt::{self, Formatter, Write};
+use core::str;
+use alloc::string::String;
+use alloc::string::ToString;
 
 use crate::host::{Host, HostInternal};
 use crate::Url;

--- a/url/src/path_segments.rs
+++ b/url/src/path_segments.rs
@@ -8,7 +8,8 @@
 
 use crate::parser::{self, to_u32, SchemeType};
 use crate::Url;
-use std::str;
+use core::str;
+use alloc::string::String;
 
 /// Exposes methods to manipulate the path of an URL that is not cannot-be-base.
 ///

--- a/url/src/path_segments.rs
+++ b/url/src/path_segments.rs
@@ -8,8 +8,8 @@
 
 use crate::parser::{self, to_u32, SchemeType};
 use crate::Url;
-use core::str;
 use alloc::string::String;
+use core::str;
 
 /// Exposes methods to manipulate the path of an URL that is not cannot-be-base.
 ///

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -13,6 +13,8 @@
 
 use crate::parser::{default_port, Context, Input, Parser, SchemeType};
 use crate::{Host, ParseError, Position, Url};
+use alloc::string::String;
+use alloc::string::ToString;
 
 /// Internal components / offsets of a URL.
 ///

--- a/url/src/slicing.rs
+++ b/url/src/slicing.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::Url;
-use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
+use core::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 
 impl Index<RangeFull> for Url {
     type Output = str;


### PR DESCRIPTION
Continuing the efforts from #831, this povides no_std support for the url crate. The default features of the url crate are changed from [ ] to [ 'std' ]. Changing the default features is a breaking change. The recommendation is to increase the major version of the url crate. The breaking change affects users who have enabled `default-features = false`. A section to the crate docs has been added with an explanation for affected users. Affected users will need to enable either the 'std' or 'alloc' feature. The MSRV is unchanged for the 'std' feature.