### PR TITLE
fix: enable wasip2 feature for wasm32-wasip2 target

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -139,6 +139,9 @@ url = { version = "2", features = ["debugger_visualizer"] }
     feature = "debugger_visualizer",
     debugger_visualizer(natvis_file = "../../debug_metadata/url.natvis")
 )]
+// We use std::os::wasi::prelude::OsStrExt, and that is conditionally feature gated
+// to be unstable on wasm32-wasip2. https://github.com/rust-lang/rust/issues/130323
+#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
 
 pub use form_urlencoded;
 


### PR DESCRIPTION
Fixes https://github.com/servo/rust-url/issues/958

Hi! 👋🏻 

[wasm32-wasip2](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip2.html) is a tier 3 target for compilation in Rust, and has landed in Rust nightly.

I'm working on https://github.com/seanmonstar/reqwest/pull/2290 and hoping to add wasm32-wasip2 support for a crate or two that depend on `url`, the compiler error currently when building shows:
```
➜ cargo +nightly build --target wasm32-wasip2
warning: /Users/brooks/github.com/servo/rust-url/url_debug_tests/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
   Compiling url v2.5.2 (/Users/brooks/github.com/servo/rust-url/url)
error[E0658]: use of unstable library feature 'wasip2'
    --> url/src/lib.rs:2836:9
     |
2836 |     use std::os::wasi::prelude::OsStrExt;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: add `#![feature(wasip2)]` to the crate attributes to enable
     = note: this compiler was built on 2024-08-06; consider upgrading it if it is out of date

error[E0658]: use of unstable library feature 'wasip2'
    --> url/src/lib.rs:2939:9
     |
2939 |     use std::os::wasi::prelude::OsStrExt;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: add `#![feature(wasip2)]` to the crate attributes to enable
     = note: this compiler was built on 2024-08-06; consider upgrading it if it is out of date

For more information about this error, try `rustc --explain E0658`.
error: could not compile `url` (lib) due to 2 previous errors
```

After this PR:
```
 ➜ cargo +nightly build --target wasm32-wasip2                                                                      
warning: /Users/brooks/github.com/servo/rust-url/url_debug_tests/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
   Compiling tinyvec_macros v0.1.1
   Compiling unicode-bidi v0.3.15
   Compiling percent-encoding v2.3.1 (/Users/brooks/github.com/servo/rust-url/percent_encoding)
   Compiling tinyvec v1.8.0
   Compiling form_urlencoded v1.2.1 (/Users/brooks/github.com/servo/rust-url/form_urlencoded)
   Compiling unicode-normalization v0.1.23
   Compiling idna v0.5.0 (/Users/brooks/github.com/servo/rust-url/idna)
   Compiling url v2.5.2 (/Users/brooks/github.com/servo/rust-url/url)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.51s
```

Because this feature is only enabled when the target OS is `wasi` and the target ENV is `p2`, this shouldn't affect any other functionality