### PR TITLE
Fix idna tests with no_std

### DIFF
--- a/idna/src/punycode.rs
+++ b/idna/src/punycode.rs
@@ -324,6 +324,6 @@ fn value_to_digit(value: u32) -> char {
 #[cfg(target_pointer_width = "64")]
 fn huge_encode() {
     let mut buf = String::new();
-    assert!(encode_into(std::iter::repeat('ß').take(u32::MAX as usize + 1), &mut buf).is_err());
+    assert!(encode_into(core::iter::repeat('ß').take(u32::MAX as usize + 1), &mut buf).is_err());
     assert_eq!(buf.len(), 0);
 }


### PR DESCRIPTION
This failed since 464b1f7d8fe9de117af184c1acb52b4f821a0cdc:

  (cd idna && cargo test --all-targets --no-default-features --features alloc -- --ignored)