### PR TITLE
Merge main to the idna-v1x branch

### DIFF
--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -17,6 +17,7 @@ alloc = []
 
 [dev-dependencies]
 tester = "0.9"
+unicode-width = "=0.1.12"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -449,8 +449,8 @@ impl<'a> PercentDecode<'a> {
 
 // std::ptr::addr_eq was stabilized in rust 1.76. Once we upgrade
 // the MSRV we can remove this lint override.
-#[allow(ambiguous_wide_pointer_comparisons)]
 #[cfg(feature = "alloc")]
+#[allow(ambiguous_wide_pointer_comparisons)]
 fn decode_utf8_lossy(input: Cow<'_, [u8]>) -> Cow<'_, str> {
     // Note: This function is duplicated in `form_urlencoded/src/query_encoding.rs`.
     match input {

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "url"
 # When updating version, also modify html_root_url in the lib.rs
-version = "2.5.1"
+version = "2.5.2"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"
@@ -14,7 +14,7 @@ categories = ["parser-implementations", "web-programming", "encoding"]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
-rust-version = "1.67"
+rust-version = "1.56"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -26,7 +26,7 @@ wasm-bindgen-test = "0.3"
 
 [dependencies]
 form_urlencoded = { version = "1.2.1", path = "../form_urlencoded" }
-idna = { version = "1.0.0", path = "../idna" }
+idna = { version = "1.0.2", path = "../idna" }
 percent-encoding = { version = "2.3.1", path = "../percent_encoding" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -134,7 +134,7 @@ url = { version = "2", features = ["debugger_visualizer"] }
 
 */
 
-#![doc(html_root_url = "https://docs.rs/url/2.5.1")]
+#![doc(html_root_url = "https://docs.rs/url/2.5.2")]
 #![cfg_attr(
     feature = "debugger_visualizer",
     debugger_visualizer(natvis_file = "../../debug_metadata/url.natvis")


### PR DESCRIPTION
The point of this merge is to have commit 54346fa288e16b25b71c45149d7067c752b450e0 in this branch but in a way where the merge node makes it pretty much go away so that merging from idna-v1x to main in the future becomes feasible without the old revert blowing away the idna 1.0.x code.