### PR TITLE
Fix and reenable debugger_visualizer test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,7 @@ jobs:
         if: |
           matrix.os == 'windows-latest' &&
           matrix.rust != '1.56.0'
-        run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1 || echo "debugger test failed"
-        continue-on-error: true # Fails on GH actions, but not locally.
+        run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1
       - name: Test `no_std` support
         run: cargo test --no-default-features --features=alloc
 

--- a/debug_metadata/url.natvis
+++ b/debug_metadata/url.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="url::Url">
-    <Intrinsic Name="ptr" Expression="serialization.vec.buf.ptr.pointer.pointer" />
+    <Intrinsic Name="ptr" Expression="serialization.vec.buf.inner.ptr.pointer.pointer" />
     <DisplayString>{serialization}</DisplayString>
     <Expand>
       <Synthetic Name="[scheme]">


### PR DESCRIPTION
The test was broken because the format for Vec had changed.
See https://github.com/rust-lang/rust/issues/130431#issuecomment-2353040738