### PR TITLE
Add AsciiSet::EMPTY and boolean operators

### DIFF
--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -120,6 +120,15 @@ impl ops::Add for AsciiSet {
     }
 }
 
+impl ops::Not for AsciiSet {
+    type Output = Self;
+
+    fn not(self) -> Self {
+        let mask = self.mask.map(|chunk| !chunk);
+        AsciiSet { mask }
+    }
+}
+
 /// The set of 0x00 to 0x1F (C0 controls), and 0x7F (DEL).
 ///
 /// Note that this includes the newline and tab characters, but not the space 0x20.
@@ -507,5 +516,13 @@ mod tests {
         let right = AsciiSet::EMPTY.add(b'B');
         let expected = AsciiSet::EMPTY.add(b'A').add(b'B');
         assert_eq!(left + right, expected);
+    }
+
+    #[test]
+    fn not() {
+        let set = AsciiSet::EMPTY.add(b'A').add(b'B');
+        let not_set = !set;
+        assert!(!not_set.contains(b'A'));
+        assert!(not_set.contains(b'C'));
     }
 }

--- a/percent_encoding/src/lib.rs
+++ b/percent_encoding/src/lib.rs
@@ -106,17 +106,30 @@ impl AsciiSet {
         mask[byte as usize / BITS_PER_CHUNK] &= !(1 << (byte as usize % BITS_PER_CHUNK));
         AsciiSet { mask }
     }
+
+    /// Return the union of two sets.
+    pub const fn union(&self, other: Self) -> Self {
+        let mask = [
+            self.mask[0] | other.mask[0],
+            self.mask[1] | other.mask[1],
+            self.mask[2] | other.mask[2],
+            self.mask[3] | other.mask[3],
+        ];
+        AsciiSet { mask }
+    }
+
+    /// Return the negation of the set.
+    pub const fn complement(&self) -> Self {
+        let mask = [!self.mask[0], !self.mask[1], !self.mask[2], !self.mask[3]];
+        AsciiSet { mask }
+    }
 }
 
 impl ops::Add for AsciiSet {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        let mut mask = self.mask.clone();
-        for i in 0..mask.len() {
-            mask[i] |= other.mask[i];
-        }
-        AsciiSet { mask }
+        self.union(other)
     }
 }
 
@@ -124,8 +137,7 @@ impl ops::Not for AsciiSet {
     type Output = Self;
 
     fn not(self) -> Self {
-        let mask = self.mask.map(|chunk| !chunk);
-        AsciiSet { mask }
+        self.complement()
     }
 }
 
@@ -511,7 +523,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn add() {
+    fn add_op() {
         let left = AsciiSet::EMPTY.add(b'A');
         let right = AsciiSet::EMPTY.add(b'B');
         let expected = AsciiSet::EMPTY.add(b'A').add(b'B');
@@ -519,10 +531,32 @@ mod tests {
     }
 
     #[test]
-    fn not() {
+    fn not_op() {
         let set = AsciiSet::EMPTY.add(b'A').add(b'B');
         let not_set = !set;
         assert!(!not_set.contains(b'A'));
         assert!(not_set.contains(b'C'));
+    }
+
+    /// This test ensures that we can get the union of two sets as a constant value, which is
+    /// useful for defining sets in a modular way.
+    #[test]
+    fn union() {
+        const A: AsciiSet = AsciiSet::EMPTY.add(b'A');
+        const B: AsciiSet = AsciiSet::EMPTY.add(b'B');
+        const UNION: AsciiSet = A.union(B);
+        const EXPECTED: AsciiSet = AsciiSet::EMPTY.add(b'A').add(b'B');
+        assert_eq!(UNION, EXPECTED);
+    }
+
+    /// This test ensures that we can get the complement of a set as a constant value, which is
+    /// useful for defining sets in a modular way.
+    #[test]
+    fn complement() {
+        const BOTH: AsciiSet = AsciiSet::EMPTY.add(b'A').add(b'B');
+        const COMPLEMENT: AsciiSet = BOTH.complement();
+        assert!(!COMPLEMENT.contains(b'A'));
+        assert!(!COMPLEMENT.contains(b'B'));
+        assert!(COMPLEMENT.contains(b'C'));
     }
 }


### PR DESCRIPTION
In RFCs, the sets of characters to percent-encode are often defined as
the union of multiple sets. This change adds an `EMPTY` constant to
`AsciiSet` and implements the `Add` trait for `AsciiSet` so that sets
can be combined with the `+` operator. The ! negation operator is also
defined, as well as equivalent constant functions for these (`union()`,
`complement()`).

AsciiSet now derives `Debug`, `PartialEq`, and `Eq` so that it can be
used in tests.

---

Example: https://www.rfc-editor.org/rfc/rfc3986#section-3.4 defines
```
   reserved      = gen-delims / sub-delims
   gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                 / "*" / "+" / "," / ";" / "="
```

Using this new method, this can be easily represented as:
```rust
const SUB_DELIMS: AsciiSet = AsciiSet::EMPTY.add(b'!').add(b'$') ...
const GEN_DELIMS: AsciiSet = AsciiSet::EMPTY.add(b':').add(b'/') ...
const RESERVED: AsciiSet = GEN_DELIMS.union(SUB_DELIMS);
```

Similarly the set of characters that must be encoded is defined as the set of characters that are not in the allowed characters

https://www.rfc-editor.org/rfc/rfc3986#section-2.2

>    URI producing applications should percent-encode data octets that
   correspond to characters in the reserved set **unless these characters
   are specifically allowed by the URI scheme to represent data in that
   component.**  If a reserved character is found in a URI component and
   no delimiting role is known for that character, then it must be
   interpreted as representing the data octet corresponding to that
   character's encoding in US-ASCII.

So a part like query is defined in https://www.rfc-editor.org/rfc/rfc3986#appendix-A as:
```
   query         = *( pchar / "/" / "?" )
   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
   unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
   pct-encoded   = "%" HEXDIG HEXDIG
   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                 / "*" / "+" / "," / ";" / "="
```
which can be translated to:
```rust
const QUERY: AsciiSet = PCHAR.add(b'/').add(b'?');
const PCHAR: AsciiSet = UNRESERVED.union(SUB_DELIMS).add(b':').add(b'@');
const UNRESERVED: AsciiSet = ...

// which can be then used like:
let encoded_query = utf8_percent_encode("foo?:@/=bar", !QUERY);
```
