### PR TITLE
Test MSRV with idna unicode-rs back end and test ICU4X back end with 1.67

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.67.0, stable, beta, nightly]
+        rust: [1.57.0, 1.67.0, stable, beta, nightly]
         exclude:
           - os: macos-latest
             rust: 1.67.0
@@ -37,6 +37,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
       # Add toolchain for no_std tests
       - run: rustup toolchain install nightly
+      - name: Downgrade idna_adapter on Rust 1.57.0
+        if: |
+          matrix.rust == '1.57.0'
+        run: cargo update -p idna_adapter --precise 1.1.0
       - name: Add `aarch64-unknown-none` toolchain for `no_std` tests
         if: |
           matrix.os == 'ubuntu-latest' &&
@@ -54,7 +58,8 @@ jobs:
       - name: Run debugger_visualizer tests
         if: |
           matrix.os == 'windows-latest' &&
-          matrix.rust != '1.56.0'
+          matrix.rust != '1.57.0' &&
+          matrix.rust != '1.67.0'
         run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1 || echo "debugger test failed"
         continue-on-error: true # Fails on GH actions, but not locally.
       - name: Test `no_std` support


### PR DESCRIPTION
Add idna_adapter awareness to CI. (The no-unicode branch of idna_adapter does not make sense to test here, since it obviously fails normal tests.)