### PR TITLE
Prepare url crate for publication with idna 1.0.3

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "url"
 # When updating version, also modify html_root_url in the lib.rs
-version = "2.5.2"
+version = "2.5.3"
 authors = ["The rust-url developers"]
 
 description = "URL library for Rust, based on the WHATWG URL Standard"
@@ -14,7 +14,7 @@ categories = ["parser-implementations", "web-programming", "encoding", "no_std"]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57" # From idna
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -26,7 +26,7 @@ wasm-bindgen-test = "0.3"
 
 [dependencies]
 form_urlencoded = { version = "1.2.1", path = "../form_urlencoded", default-features = false, features = ["alloc"] }
-idna = { version = "1.0.2", path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
+idna = { version = "1.0.3", path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
 percent-encoding = { version = "2.3.1", path = "../percent_encoding", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -143,7 +143,7 @@ url = { version = "2", features = ["debugger_visualizer"] }
 */
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/url/2.5.2")]
+#![doc(html_root_url = "https://docs.rs/url/2.5.3")]
 #![cfg_attr(
     feature = "debugger_visualizer",
     debugger_visualizer(natvis_file = "../../debug_metadata/url.natvis")


### PR DESCRIPTION
Prepare the idna-v1x branch so that `url` 2.5.3 depending on `idna` 1.0.3 could be published from it.

However, instead of actually publishing `url` 2.5.3 and `idna` 1.0.3 from the idna-v1x branch, my expectation is that after this PR has landed, we'd merge idna-v1x into main, at which point `url` 2.5.3 and `idna` 1.0.3 could be published from main and the idna-v1x branch would become obsolete.