### PR TITLE
Make the port of `Origin` be an `Option<u16>`

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -820,7 +820,7 @@ impl Url {
     /// assert_eq!(url.origin(),
     ///            Origin::Tuple("ftp".into(),
     ///                          Host::Domain("example.com".into()),
-    ///                          21));
+    ///                          None));
     /// # Ok(())
     /// # }
     /// # run().unwrap();
@@ -837,7 +837,7 @@ impl Url {
     /// assert_eq!(url.origin(),
     ///            Origin::Tuple("https".into(),
     ///                          Host::Domain("example.com".into()),
-    ///                          443));
+    ///                          None));
     /// # Ok(())
     /// # }
     /// # run().unwrap();

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -668,6 +668,31 @@ fn test_origin_unicode_serialization() {
 }
 
 #[test]
+fn test_origin_default_port() {
+    let urls_and_expected_origin_ports = [
+        ("http://example.com:80", None),
+        ("http://example.com", None),
+        ("https://example.com:443", None),
+        ("https://example.com", None),
+        ("ftp://127.0.0.1:21/", None),
+        ("ftp://127.0.0.1/", None),
+        ("http://example.com:221", Some(221)),
+        ("http://example.com:123", Some(123)),
+        ("https://example.com:442", Some(442)),
+        ("https://example.com:80", Some(80)),
+        ("ftp://127.0.0.1:20/", Some(20)),
+        ("ftp://127.0.0.1:80/", Some(80)),
+    ];
+
+    for (url_string, expected_port) in &urls_and_expected_origin_ports {
+        match Url::parse(url_string).unwrap().origin() {
+            Origin::Opaque(..) => unreachable!("Should not have found an opaque origin."),
+            Origin::Tuple(_, _, port) => assert_eq!(port, *expected_port),
+        }
+    }
+}
+
+#[test]
 #[cfg(feature = "std")]
 #[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
 fn test_socket_addrs() {


### PR DESCRIPTION
The URL specification changed in 2016 [1] [2] such that now the origin's port
should be the same as the URL's port. This means that the port can
`None` in the case that it is the default port for a scheme.

1. https://github.com/whatwg/url/commit/b0e4def5b62e0be2d75b4b7b5720a5e0ea879596
2. https://github.com/whatwg/html/pull/870

Fixes #821.
