### PR TITLE
Add support for SQLx types

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.57" # From idna
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bencher = "0.1"
+sqlx-core = "0.8"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
@@ -29,10 +30,12 @@ form_urlencoded = { version = "1.2.1", path = "../form_urlencoded", default-feat
 idna = { version = "1.0.3", path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
 percent-encoding = { version = "2.3.1", path = "../percent_encoding", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+sqlx = { version = "0.8", optional = true }
 
 [features]
 default = ["std"]
 std = ["idna/std", "percent-encoding/std", "form_urlencoded/std"]
+sqlx_postgres = ["sqlx", "sqlx/postgres"]
 
 # Enable to use the #[debugger_visualizer] attribute. This feature requires Rust >= 1.71.
 debugger_visualizer = []

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1379,3 +1379,35 @@ fn serde_error_message() {
         r#"relative URL without a base: "§invalid#+#*Ä" at line 1 column 25"#
     );
 }
+
+#[cfg(feature = "sqlx")]
+#[test]
+fn sqlx_url_error() {
+    use sqlx::{any::AnyValue, Any, Decode, Value};
+    use sqlx_core::any::AnyValueKind;
+    use url::ParseError;
+
+    let value = AnyValue {
+        kind: AnyValueKind::Text(Cow::from("§invalid#+#*Ä")),
+    };
+    let boxed_err = <Url as Decode<'_, Any>>::decode(value.as_ref()).unwrap_err();
+    let err = boxed_err.downcast::<ParseError>().unwrap();
+
+    assert_eq!(*err, ParseError::RelativeUrlWithoutBase);
+}
+
+#[cfg(feature = "sqlx")]
+#[test]
+fn sqlx_host_error() {
+    use sqlx::{any::AnyValue, Any, Decode, Value};
+    use sqlx_core::any::AnyValueKind;
+    use url::ParseError;
+
+    let value = AnyValue {
+        kind: AnyValueKind::Text(Cow::from("§invalid#+#*Ä")),
+    };
+    let boxed_err = <Host as Decode<'_, Any>>::decode(value.as_ref()).unwrap_err();
+    let err = boxed_err.downcast::<ParseError>().unwrap();
+
+    assert_eq!(*err, ParseError::IdnaError);
+}


### PR DESCRIPTION
Adds support for encoding to/decoding from SQLx types. This allows you to store or read URL values from the database while ensuring that it's always valid.

The PR adds two new optional features:

- `sqlx`: Enables encoding/decoding between URLs and SQLx types
- `sqlx_postgres`: Like above, but also enables array encoding/decoding for PostgreSQL databases