### PR TITLE
Revert "Normalize URL paths: convert /.//p, /..//p, and //p to p (#943)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.57.0, 1.67.0, stable, beta, nightly]
+        rust: [1.63.0, 1.67.0, stable, beta, nightly]
         exclude:
           - os: macos-latest
             rust: 1.67.0
@@ -37,9 +37,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
       # Add toolchain for no_std tests
       - run: rustup toolchain install nightly
-      - name: Downgrade idna_adapter on Rust 1.57.0
+      - name: Downgrade idna_adapter on Rust 1.63.0
         if: |
-          matrix.rust == '1.57.0'
+          matrix.rust == '1.63.0'
         run: cargo update -p idna_adapter --precise 1.1.0
       - name: Add `aarch64-unknown-none` toolchain for `no_std` tests
         if: |
@@ -58,7 +58,7 @@ jobs:
       - name: Run debugger_visualizer tests
         if: |
           matrix.os == 'windows-latest' &&
-          matrix.rust != '1.57.0' &&
+          matrix.rust != '1.63.0' &&
           matrix.rust != '1.67.0'
         run: cargo test --test debugger_visualizer --features "url/debugger_visualizer,url_debug_tests/debugger_visualizer" -- --test-threads=1 || echo "debugger test failed"
         continue-on-error: true # Fails on GH actions, but not locally.

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["parser-implementations", "web-programming", "encoding", "no-std"]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md", "tests/**"]
 edition = "2018"
-rust-version = "1.57" # From idna
+rust-version = "1.63" # From libc
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -1757,39 +1757,6 @@ impl Url {
         let old_after_path_pos = to_u32(self.serialization.len()).unwrap();
         let cannot_be_a_base = self.cannot_be_a_base();
         let scheme_type = SchemeType::from(self.scheme());
-        let mut path_empty = false;
-
-        // Check ':' and then see if the next character is '/'
-        let mut has_host = if let Some(index) = self.serialization.find(":") {
-            if self.serialization.len() > index + 1
-                && self.serialization.as_bytes().get(index + 1) == Some(&b'/')
-            {
-                let rest = &self.serialization[(index + ":/".len())..];
-                let host_part = rest.split('/').next().unwrap_or("");
-                path_empty = rest.is_empty();
-                !host_part.is_empty() && !host_part.contains('@')
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-
-        // Ensure the path length is greater than 1 to account
-        // for cases where "/." is already appended from serialization
-        // If we set path, then we already checked the other two conditions:
-        // https://url.spec.whatwg.org/#url-serializing
-        // 1. The host is null
-        // 2. the first segment of the URL's path is an empty string
-        if path.len() > 1 {
-            if let Some(index) = self.serialization.find(":") {
-                let removal_start = index + ":".len();
-                if self.serialization[removal_start..].starts_with("/.") {
-                    self.path_start -= "/.".len() as u32;
-                }
-            }
-        }
-
         self.serialization.truncate(self.path_start as usize);
         self.mutate(|parser| {
             if cannot_be_a_base {
@@ -1799,6 +1766,7 @@ impl Url {
                 }
                 parser.parse_cannot_be_a_base_path(parser::Input::new_no_trim(path));
             } else {
+                let mut has_host = true; // FIXME
                 parser.parse_path_start(
                     scheme_type,
                     &mut has_host,
@@ -1806,26 +1774,6 @@ impl Url {
                 );
             }
         });
-
-        // For cases where normalization is applied across both the serialization and the path.
-        // Append "/." immediately after the scheme (up to ":")
-        // This is done if three conditions are met.
-        // https://url.spec.whatwg.org/#url-serializing
-        // 1. The host is null
-        // 2. The url's path length is greater than 1
-        // 3. the first segment of the URL's path is an empty string
-        if !has_host && path.len() > 1 && path_empty {
-            if let Some(index) = self.serialization.find(":") {
-                if self.serialization.len() > index + 2
-                    && self.serialization.as_bytes().get(index + 1) == Some(&b'/')
-                    && self.serialization.as_bytes().get(index + 2) == Some(&b'/')
-                {
-                    self.serialization.insert_str(index + ":".len(), "/.");
-                    self.path_start += "/.".len() as u32;
-                }
-            }
-        }
-
         self.restore_after_path(old_after_path_pos, &after_path);
     }
 

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -43,3 +43,7 @@
 <file://monkey/> set pathname to <\\\\>
 <file:///unicorn> set pathname to <//\\/>
 <file:///unicorn> set pathname to <//monkey/..//>
+<non-spec:/> set pathname to </.//p>
+<non-spec:/> set pathname to </..//p>
+<non-spec:/> set pathname to <//p>
+<non-spec:/.//> set pathname to <p>


### PR DESCRIPTION
This reverts commit b08a655d07f355dcce110922a9b30c1602236124.

This also updates the MSRV to 1.63 - required though the libc v0.2.164 dependency 