### PR TITLE
ci: run unit tests with sanitizers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,6 @@ jobs:
             rust: beta
           - os: windows-latest
             rust: beta
-          - os: macos-latest
-            rust: nightly
 
     runs-on: ${{ matrix.os }}
 
@@ -35,6 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+          components: ${{ matrix.rust == 'nightly' && 'rust-src' || '' }}
       # Add toolchain for no_std tests
       - run: rustup toolchain install nightly
       - name: Downgrade deps on Rust 1.63.0
@@ -79,6 +78,32 @@ jobs:
         run: >
           cd url
           && cargo check --target aarch64-unknown-none -v --no-default-features
+      - name: Run tests with sanitizers
+        if: (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && matrix.rust == 'nightly'
+        env:
+          ASAN_OPTIONS: detect_leaks=1:detect_stack_use_after_return=1
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo apt-get install -y --no-install-recommends llvm
+            TARGET="x86_64-unknown-linux-gnu"
+            SANITIZERS="address thread leak memory"
+          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+            TARGET="aarch64-apple-darwin"
+            # no memory and leak sanitizer support yet
+            SANITIZERS="address thread"
+            # Suppress non-crate leaks on macOS. TODO: Check occasionally if these are still needed.
+            {
+              echo "leak:dyld4::RuntimeState"
+              echo "leak:fetchInitializingClassList"
+            } > suppressions.txt
+            export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
+          fi
+          for sanitizer in $SANITIZERS; do
+            echo "Running tests with $sanitizer sanitizer..."
+            export RUSTFLAGS="-Z sanitizer=$sanitizer"
+            export RUSTDOCFLAGS="$RUSTFLAGS"
+            cargo +nightly test -Z build-std --target "$TARGET"
+          done
 
   WASM:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a GitHub Workflow Step, running `cargo test` with various sanitizers on Ubuntu and MacOS.

See similar work in https://github.com/mozilla/mtu/pull/5 and https://github.com/mozilla/neqo/pull/2143.