### PR TITLE
ci: downgrade crates when building for Rust 1.67.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,18 @@ jobs:
           toolchain: ${{ matrix.rust }}
       # Add toolchain for no_std tests
       - run: rustup toolchain install nightly
-      - name: Downgrade idna_adapter on Rust 1.63.0
+      - name: Downgrade deps on Rust 1.63.0
         if: |
           matrix.rust == '1.63.0'
-        run: cargo update -p idna_adapter --precise 1.1.0
+        run: |
+          cargo update -p idna_adapter --precise 1.1.0
+      - name: Downgrade deps on Rust 1.67.0
+        if: |
+          matrix.rust == '1.67.0'
+        run: |
+          cargo update -p zerofrom --precise 0.1.4
+          cargo update -p yoke --precise 0.7.4
+          cargo update -p litemap --precise 0.7.3
       - name: Add `aarch64-unknown-none` toolchain for `no_std` tests
         if: |
           matrix.os == 'ubuntu-latest' &&


### PR DESCRIPTION
Crates from the https://github.com/unicode-org/icu4x workspace got a round of releases recently, increasing the minimum Rust version.

When building this project with Rust 1.67.0, make sure to downgrade some of the dependencies like is already done for Rust 1.63.0.

See sample failure:

https://github.com/mxinden/rust-url/actions/runs/12047186281/job/33589206151