### PR TITLE
perf: improve to_file_path()

### DIFF
--- a/url/benches/parse_url.rs
+++ b/url/benches/parse_url.rs
@@ -82,6 +82,19 @@ fn punycode_rtl(bench: &mut Bencher) {
     bench.iter(|| black_box(url).parse::<Url>().unwrap());
 }
 
+fn url_to_file_path(bench: &mut Bencher) {
+    let url = if cfg!(windows) {
+        "file:///C:/dir/next_dir/sub_sub_dir/testing/testing.json"
+    } else {
+        "file:///data/dir/next_dir/sub_sub_dir/testing/testing.json"
+    };
+    let url = url.parse::<Url>().unwrap();
+
+    bench.iter(|| {
+        black_box(url.to_file_path().unwrap());
+    });
+}
+
 benchmark_group!(
     benches,
     short,
@@ -95,5 +108,6 @@ benchmark_group!(
     punycode_ltr,
     unicode_rtl,
     punycode_rtl,
+    url_to_file_path
 );
 benchmark_main!(benches);

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -3067,7 +3067,8 @@ fn file_url_segments_to_pathbuf(
         return Err(());
     }
 
-    let mut bytes = Vec::with_capacity(estimated_capacity);
+    let mut bytes = Vec::new();
+    bytes.try_reserve(estimated_capacity).map_err(|_| ())?;
     if cfg!(target_os = "redox") {
         bytes.extend(b"file:");
     }

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -3103,7 +3103,7 @@ fn file_url_segments_to_pathbuf_windows(
     use percent_encoding::percent_decode_str;
     let mut string = String::with_capacity(estimated_capacity);
     if let Some(host) = host {
-        string.push('\\');
+        string.push_str(r"\\");
         string.push_str(host);
     } else {
         let first = segments.next().ok_or(())?;


### PR DESCRIPTION
Reduces some heap allocations and pre-allocates the vector for building the string.