### PR TITLE
perf: remove heap allocation in parse_query

### DIFF
--- a/url/benches/parse_url.rs
+++ b/url/benches/parse_url.rs
@@ -19,6 +19,13 @@ fn long(bench: &mut Bencher) {
     bench.iter(|| black_box(url).parse::<Url>().unwrap());
 }
 
+fn long_with_fragment(bench: &mut Bencher) {
+    let url = "https://example.com/parkbench?tre=es&st=uff#fragment";
+
+    bench.bytes = url.len() as u64;
+    bench.iter(|| black_box(url).parse::<Url>().unwrap());
+}
+
 fn plain(bench: &mut Bencher) {
     let url = "https://example.com/";
 
@@ -86,6 +93,7 @@ benchmark_group!(
     benches,
     short,
     long,
+    long_with_fragment,
     plain,
     hyphen,
     leading_digit,

--- a/url/benches/parse_url.rs
+++ b/url/benches/parse_url.rs
@@ -19,7 +19,7 @@ fn long(bench: &mut Bencher) {
     bench.iter(|| black_box(url).parse::<Url>().unwrap());
 }
 
-fn long_with_fragment(bench: &mut Bencher) {
+fn fragment(bench: &mut Bencher) {
     let url = "https://example.com/parkbench?tre=es&st=uff#fragment";
 
     bench.bytes = url.len() as u64;
@@ -93,7 +93,7 @@ benchmark_group!(
     benches,
     short,
     long,
-    long_with_fragment,
+    fragment,
     plain,
     hyphen,
     leading_digit,

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1475,13 +1475,13 @@ impl<'a> Parser<'a> {
         scheme_end: u32,
         input: Input<'i>,
     ) -> Option<Input<'i>> {
-        struct PartIter<'i, 'p> {
+        struct QueryPartIter<'i, 'p> {
             is_url_parser: bool,
             input: Input<'i>,
             violation_fn: Option<&'p dyn Fn(SyntaxViolation)>,
         }
 
-        impl<'i> Iterator for PartIter<'i, '_> {
+        impl<'i> Iterator for QueryPartIter<'i, '_> {
             type Item = (&'i str, bool);
 
             fn next(&mut self) -> Option<Self::Item> {
@@ -1517,7 +1517,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let mut part_iter = PartIter {
+        let mut part_iter = QueryPartIter {
             is_url_parser: self.context == Context::UrlParser,
             input,
             violation_fn: self.violation_fn,
@@ -1570,15 +1570,54 @@ impl<'a> Parser<'a> {
         })
     }
 
-    pub fn parse_fragment(&mut self, mut input: Input<'_>) {
-        while let Some((c, utf8_c)) = input.next_utf8() {
-            if c == '\0' {
-                self.log_violation(SyntaxViolation::NullInFragment)
-            } else {
-                self.check_url_code_point(c, &input);
+    pub fn parse_fragment(&mut self, input: Input<'_>) {
+        struct FragmentPartIter<'i, 'p> {
+            input: Input<'i>,
+            violation_fn: Option<&'p dyn Fn(SyntaxViolation)>,
+        }
+
+        impl<'i> Iterator for FragmentPartIter<'i, '_> {
+            type Item = &'i str;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                let start = self.input.chars.as_str();
+                // bypass self.input.next() in order to get string slices
+                // which are faster to operate on
+                while let Some(c) = self.input.chars.next() {
+                    match c {
+                        '\t' | '\n' | '\r' => {
+                            return Some(
+                                &start[..start.len() - self.input.chars.as_str().len() - 1],
+                            );
+                        }
+                        '\0' => {
+                            if let Some(vfn) = &self.violation_fn {
+                                vfn(SyntaxViolation::NullInFragment);
+                            }
+                        }
+                        c => {
+                            if let Some(vfn) = &self.violation_fn {
+                                check_url_code_point(vfn, c, &self.input);
+                            }
+                        }
+                    }
+                }
+                if start.is_empty() {
+                    None
+                } else {
+                    Some(start)
+                }
             }
+        }
+
+        let part_iter = FragmentPartIter {
+            input,
+            violation_fn: self.violation_fn,
+        };
+
+        for part in part_iter {
             self.serialization
-                .extend(utf8_percent_encode(utf8_c, FRAGMENT));
+                .extend(utf8_percent_encode(part, FRAGMENT));
         }
     }
 

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1487,6 +1487,7 @@ impl<'a> Parser<'a> {
             fn next(&mut self) -> Option<Self::Item> {
                 let start = self.input.chars.as_str();
                 // bypass self.input.next() in order to get string slices
+                // which are faster to operate on
                 while let Some(c) = self.input.chars.next() {
                     match c {
                         '\t' | '\n' | '\r' => {
@@ -1533,7 +1534,7 @@ impl<'a> Parser<'a> {
             )
         });
 
-        // it's faster to be repetitive here
+        // it's slightly faster to be repetitive here
         match query_encoding_override {
             Some(o) => {
                 while let Some((part, is_finished)) = part_iter.next() {


### PR DESCRIPTION
Also updates parse_fragment to work similarly to how parse_query works now where it operates on longer string slices for percent decoding, which helps to not have to do that for every character.

Before:

```
test long           ... bench:         302 ns/iter (+/- 42) = 142 MB/s
test fragment       ... bench:         370 ns/iter (+/- 9) = 140 MB/s
```

After:

```
test long           ... bench:         243 ns/iter (+/- 7) = 176 MB/s
test fragment       ... bench:         275 ns/iter (+/- 9) = 189 MB/s
```