### PR TITLE
perf: make parse_scheme slightly faster

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -398,8 +398,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_scheme<'i>(&mut self, mut input: Input<'i>) -> Result<Input<'i>, ()> {
-        // starts_with will also fail for empty strings
-        // so we can skip that comparison for perf
+        // starts_with will also fail for empty strings so we can skip that comparison for perf
         if !input.starts_with(ascii_alpha) {
             return Err(());
         }

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -398,15 +398,14 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_scheme<'i>(&mut self, mut input: Input<'i>) -> Result<Input<'i>, ()> {
-        if input.is_empty() || !input.starts_with(ascii_alpha) {
+        if !input.starts_with(ascii_alpha) {
             return Err(());
         }
         debug_assert!(self.serialization.is_empty());
         while let Some(c) = input.next() {
             match c {
-                'a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '-' | '.' => {
-                    self.serialization.push(c.to_ascii_lowercase())
-                }
+                'a'..='z' | '0'..='9' | '+' | '-' | '.' => self.serialization.push(c),
+                'A'..='Z' => self.serialization.push(c.to_ascii_lowercase()),
                 ':' => return Ok(input),
                 _ => {
                     self.serialization.clear();

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -398,6 +398,8 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_scheme<'i>(&mut self, mut input: Input<'i>) -> Result<Input<'i>, ()> {
+        // starts_with will also fail for empty strings
+        // so we can skip that comparison for perf
         if !input.starts_with(ascii_alpha) {
             return Err(());
         }

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1032,6 +1032,14 @@ fn test_set_scheme_to_file_with_host() {
 }
 
 #[test]
+fn test_set_scheme_empty_err() {
+    let mut url: Url = "http://localhost:6767/foo/bar".parse().unwrap();
+    let result = url.set_scheme("");
+    assert_eq!(url.to_string(), "http://localhost:6767/foo/bar");
+    assert_eq!(result, Err(()));
+}
+
+#[test]
 fn no_panic() {
     let mut url = Url::parse("arhttpsps:/.//eom/dae.com/\\\\t\\:").unwrap();
     url::quirks::set_hostname(&mut url, "//eom/datcom/\\\\t\\://eom/data.cs").unwrap();


### PR DESCRIPTION
Avoids a check that's already covered by another check and avoids doing a `is_ascii_uppercase()` check in `to_ascii_lowercase()` when we know the character is lowercase.

Before:

```
test short          ... bench:         189 ns/iter (+/- 6) = 132 MB/s
```

After:

```
test short          ... bench:         182 ns/iter (+/- 5) = 137 MB/s
```