### PR TITLE
Add some some basic functions to `Mime`

### DIFF
--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_json = "1.0"
 
 [lib]
-test = false
+test = true
 
 [[test]]
 name = "wpt"

--- a/data-url/README.md
+++ b/data-url/README.md
@@ -13,8 +13,7 @@ use data_url::{DataUrl, mime};
 let url = DataUrl::process("data:,Hello%20World!").unwrap();
 let (body, fragment) = url.decode_to_vec().unwrap();
 
-assert_eq!(url.mime_type().type_, "text");
-assert_eq!(url.mime_type().subtype, "plain");
+assert!(url.mime_type().is("text", "plain"));
 assert_eq!(url.mime_type().get_parameter("charset"), Some("US-ASCII"));
 assert_eq!(body, b"Hello World!");
 assert!(fragment.is_none());

--- a/data-url/src/lib.rs
+++ b/data-url/src/lib.rs
@@ -8,8 +8,7 @@
 //! let url = DataUrl::process("data:,Hello%20World!").unwrap();
 //! let (body, fragment) = url.decode_to_vec().unwrap();
 //!
-//! assert_eq!(url.mime_type().type_, "text");
-//! assert_eq!(url.mime_type().subtype, "plain");
+//! assert!(url.mime_type().matches("text", "plain"));
 //! assert_eq!(url.mime_type().get_parameter("charset"), Some("US-ASCII"));
 //! assert_eq!(body, b"Hello World!");
 //! assert!(fragment.is_none());

--- a/data-url/src/mime.rs
+++ b/data-url/src/mime.rs
@@ -3,7 +3,7 @@ use core::fmt::{self, Write};
 use core::str::FromStr;
 
 /// <https://mimesniff.spec.whatwg.org/#mime-type-representation>
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Mime {
     pub type_: String,
     pub subtype: String,
@@ -12,6 +12,22 @@ pub struct Mime {
 }
 
 impl Mime {
+    /// Construct a new [`Mime`] with the given `type_` and `subtype` and an
+    /// empty parameter list.
+    pub fn new(type_: &str, subtype: &str) -> Self {
+        Self {
+            type_: type_.into(),
+            subtype: subtype.into(),
+            parameters: vec![],
+        }
+    }
+
+    /// Return true if this [`Mime`] matches a given type and subtype, regardless
+    /// of what parameters it has.
+    pub fn matches(&self, type_: &str, subtype: &str) -> bool {
+        self.type_ == type_ && self.subtype == subtype
+    }
+
     pub fn get_parameter<P>(&self, name: &P) -> Option<&str>
     where
         P: ?Sized + PartialEq<str>,
@@ -205,3 +221,19 @@ static IS_HTTP_TOKEN: [bool; 256] = byte_map![
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
+
+#[test]
+fn test_basic_mime() {
+    let mime = Mime::new("text", "plain");
+    assert!(mime.matches("text", "plain"));
+
+    let cloned = mime.clone();
+    assert!(cloned.matches("text", "plain"));
+
+    let mime = Mime {
+        type_: "text".into(),
+        subtype: "html".into(),
+        parameters: vec![("one".into(), "two".into())],
+    };
+    assert!(mime.matches("text", "html"));
+}


### PR DESCRIPTION
This adds `Clone`, `fn new()`, and `fn matches()` to `Mime`. Servo uses
`data_url::Mime` in places as it supports charsets and these helpers
make it a lot nicer to use.
