### PR TITLE
Export AsciiSets and add some links to standards to AsciiSets documentation

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -173,7 +173,13 @@ use crate::net::IpAddr;
     target_os = "hermit"
 ))]
 use crate::net::{SocketAddr, ToSocketAddrs};
-use crate::parser::{to_u32, Context, Parser, SchemeType, USERINFO};
+use crate::parser::{to_u32, Context, Parser, SchemeType};
+
+// Exporting all standard AsciiSets for general use
+pub use crate::parser::{
+    FRAGMENT, PATH, PATH_SEGMENT, QUERY, SPECIAL_PATH_SEGMENT, SPECIAL_QUERY, USERINFO,
+};
+
 use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
 use alloc::str;

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -17,13 +17,13 @@ use form_urlencoded::EncodingOverride;
 use percent_encoding::{percent_encode, utf8_percent_encode, AsciiSet, CONTROLS};
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
-const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+pub const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
 
 /// https://url.spec.whatwg.org/#path-percent-encode-set
-const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
+pub const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
 
 /// https://url.spec.whatwg.org/#userinfo-percent-encode-set
-pub(crate) const USERINFO: &AsciiSet = &PATH
+pub const USERINFO: &AsciiSet = &PATH
     .add(b'/')
     .add(b':')
     .add(b';')
@@ -35,15 +35,15 @@ pub(crate) const USERINFO: &AsciiSet = &PATH
     .add(b'^')
     .add(b'|');
 
-pub(crate) const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
+pub const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
 
 // The backslash (\) character is treated as a path separator in special URLs
 // so it needs to be additionally escaped in that case.
-pub(crate) const SPECIAL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'\\');
+pub const SPECIAL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'\\');
 
 // https://url.spec.whatwg.org/#query-state
-const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
-const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');
+pub const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
+pub const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');
 
 pub type ParseResult<T> = Result<T, ParseError>;
 

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -41,7 +41,7 @@ pub const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
 // so it needs to be additionally escaped in that case.
 pub const SPECIAL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'\\');
 
-// https://url.spec.whatwg.org/#query-state
+/// https://url.spec.whatwg.org/#query-state
 pub const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
 pub const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');
 

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -42,7 +42,9 @@ pub const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
 pub const SPECIAL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'\\');
 
 /// https://url.spec.whatwg.org/#query-state
+/// https://url.spec.whatwg.org/#query-percent-encode-set
 pub const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
+/// https://url.spec.whatwg.org/#special-query-percent-encode-set
 pub const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');
 
 pub type ParseResult<T> = Result<T, ParseError>;


### PR DESCRIPTION
This allows to re-use the AsciiSets for users of this library.

Having the AsciiSets public helps to update Urls.

For example
`set_password` only allows to set utf-8 passwords. Setting a new 8-bit,
non-utf-8 password requires to percent-encode it beforehand. So one had
to rebuild the `USERINFO` AsciiSet to encode it. To avoid requiring
such duplications, we make the AsciiSets public.