### PR TITLE
Enable no-std environments with `serde` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "url",
   "form_urlencoded",

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen-test = "0.3"
 form_urlencoded = { version = "1.2.1", path = "../form_urlencoded", default-features = false, features = ["alloc"] }
 idna = { version = "1.0.3", path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
 percent-encoding = { version = "2.3.1", path = "../percent_encoding", default-features = false, features = ["alloc"] }
-serde = { version = "1.0", optional = true, features = ["derive"], default-features = false }
+serde = { version = "1.0", optional = true, features = ["alloc", "derive"], default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Enable compilation in no-std environments when the "serde" feature flag is enabled.

 I guess this is breaking but not sure.