### PR TITLE
set_hostname should error when encountering colon ':'

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -246,7 +246,7 @@ impl<'i> Input<'i> {
     }
 
     #[inline]
-    fn starts_with<P: Pattern>(&self, p: P) -> bool {
+    pub fn starts_with<P: Pattern>(&self, p: P) -> bool {
         p.split_prefix(&mut self.clone())
     }
 

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -212,7 +212,10 @@ pub fn set_hostname(url: &mut Url, new_hostname: &str) -> Result<(), ()> {
         return Ok(());
     }
 
-    if let Ok((host, _remaining)) = Parser::parse_host(input, scheme_type) {
+    if let Ok((host, remaining)) = Parser::parse_host(input, scheme_type) {
+        if remaining.starts_with(':') {
+            return Err(());
+        };
         if let Host::Domain(h) = &host {
             if h.is_empty() {
                 // Empty host on special not file url

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -34,8 +34,6 @@
 <file:///.//> against <file:////>
 <file:.//p>
 <file:/.//p>
-<http://example.net/path> set hostname to <example.com:8080>
-<http://example.net:8080/path> set hostname to <example.com:>
 <non-spec:/.//p> set hostname to <h>
 <non-spec:/.//p> set hostname to <>
 <foo:///some/path> set pathname to <>


### PR DESCRIPTION
When setting via hostname api, the spec notes [in the basic url parser](https://url.spec.whatwg.org/#hostname-state) that when we encounter a colon ":":

> If state override is given and state override is [hostname state](https://url.spec.whatwg.org/#hostname-state), then return failure.