### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,8 @@ jobs:
               echo "leak:dyld4::RuntimeState"
               echo "leak:fetchInitializingClassList"
               echo "leak:std::sys::pal::unix::stack_overflow::imp::init"
+              echo "leak:dyld::ThreadLocalVariables::instantiateVariable"
+              echo "leak:_tlv_get_addr"
             } > suppressions.txt
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"
           fi

--- a/data-url/Cargo.toml
+++ b/data-url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-url"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Processing of data: URL according to WHATWG’s Fetch Standard"
 categories = ["no_std"]

--- a/form_urlencoded/Cargo.toml
+++ b/form_urlencoded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["The rust-url developers"]
 description = "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms."
 categories = ["no_std"]

--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 authors = ["The rust-url developers"]
 description = "IDNA (Internationalizing Domain Names in Applications) and Punycode."
 keywords = ["no_std", "web", "http"]

--- a/percent_encoding/Cargo.toml
+++ b/percent_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 authors = ["The rust-url developers"]
 description = "Percent encoding and decoding"
 categories = ["no_std"]


### PR DESCRIPTION
Some of the changes in https://github.com/servo/rust-url/compare/v2.5.4...v2.5.5 require a patch bump, while https://github.com/servo/rust-url/commit/68f151c01682d620605b749b61684084150a6c41 needs a minor version bump as it changes behaviour.