### PR TITLE
fix: add Serde std feature if needed

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", optional = true, features = ["derive"], default-featu
 
 [features]
 default = ["std"]
-std = ["idna/std", "percent-encoding/std", "form_urlencoded/std"]
+std = ["idna/std", "percent-encoding/std", "form_urlencoded/std", "serde/std"]
 
 # Enable to use the #[debugger_visualizer] attribute. This feature requires Rust >= 1.71.
 debugger_visualizer = []


### PR DESCRIPTION
There is an issue introduced by #1033 
Serde no longer include std feature that result in an error when using url with serde feature:
```
error[E0599]: the method `serialize` exists for tuple `(&String, &u32, &u32, &u32, &u32, &HostInternal, &core::option::Option<u16>, &u32, &core::option::Option<u32>, &core::option::Option<u32>)`, but its trait bounds were not satisfied
    --> /Users/jht/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/url-2.5.6/src/lib.rs:2648:14
     |
2636 | /         (
2637 | |             serialization,
2638 | |             scheme_end,
2639 | |             username_end,
...    |
2648 | |             .serialize(serializer)
     | |             -^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
     | |_____________|
     |
     |
     = note: the following trait bounds were not satisfied:
             `&String: Serialize`
             which is required by `(&String, &u32, &u32, &u32, &u32, &HostInternal, &core::option::Option<u16>, &u32, &core::option::Option<u32>, &core::option::Option<u32>): Serialize`

error[E0277]: the trait bound `String: Deserialize<'_>` is not satisfied
    --> /Users/jht/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/url-2.5.6/src/lib.rs:2675:13
     |
2675 |         ) = Deserialize::deserialize(deserializer)?;
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `String`
     |
     = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `String` type
     = note: for types from other crates check whether the crate offers a `serde` feature flag
     = help: the trait `Deserialize<'_>` is not implemented for `String`
             but it is implemented for `&str`
     = help: for that trait implementation, expected `&str`, found `String`
     = note: required for `(String, _, _, _, _, _, _, _, _, _)` to implement `Deserialize<'_>`
```

This PR solve this by adding the `std` flag if needed to serde.
I've test it for my project, it work.