### PR TITLE
make serde std feature use optional syntax

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", optional = true, features = ["derive"], default-featu
 
 [features]
 default = ["std"]
-std = ["idna/std", "percent-encoding/std", "form_urlencoded/std", "serde/std"]
+std = ["idna/std", "percent-encoding/std", "form_urlencoded/std", "serde?/std"]
 
 # Enable to use the #[debugger_visualizer] attribute. This feature requires Rust >= 1.71.
 debugger_visualizer = []


### PR DESCRIPTION
This was added in #1068, from which serde was pulled unconditionally, use optional syntax https://doc.rust-lang.org/cargo/reference/features.html#dependency-features. I believe that this is what initially was intended.