### PR TITLE
fix outdated docs for ParseError

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -52,7 +52,7 @@ macro_rules! simple_enum_error {
         /// Errors that can occur during parsing.
         ///
         /// This may be extended in the future so exhaustive matching is
-        /// discouraged with an unused variant.
+        /// forbidden.
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         #[non_exhaustive]
         pub enum ParseError {


### PR DESCRIPTION
The referenced unused variant seems to have been removed in commit 52d736e with the move to `#[non_exhaustive]`.