### PR TITLE
Improve Compile Times with `serde_derive`

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -17,7 +17,8 @@ edition = "2018"
 rust-version = "1.63" # From libc
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
+serde_derive = "1.0"
 serde_json = "1.0"
 bencher = "0.1"
 
@@ -28,7 +29,8 @@ wasm-bindgen-test = "0.3"
 form_urlencoded = { version = "1.2.2", path = "../form_urlencoded", default-features = false, features = ["alloc"] }
 idna = { version = "1.1.0", path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
 percent-encoding = { version = "2.3.2", path = "../percent_encoding", default-features = false, features = ["alloc"] }
-serde = { version = "1.0", optional = true, features = ["derive"], default-features = false }
+serde = { version = "1.0", optional = true, default-features = false }
+serde_derive = { version = "1.0", optional = true, default-features = false }
 
 [features]
 default = ["std"]
@@ -38,6 +40,8 @@ std = ["idna/std", "percent-encoding/std", "form_urlencoded/std", "serde?/std"]
 debugger_visualizer = []
 # Expose internal offsets of the URL.
 expose_internals = []
+# Enables serialization and deserialization via serde.
+serde = ["dep:serde", "dep:serde_derive"]
 
 [[test]]
 name = "url_wpt"

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -16,7 +16,7 @@ use core::fmt::{self, Formatter};
 
 use percent_encoding::{percent_decode, utf8_percent_encode, CONTROLS};
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::parser::{ParseError, ParseResult};
 

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1370,7 +1370,7 @@ fn issue_974() {
 #[cfg(feature = "serde")]
 #[test]
 fn serde_error_message() {
-    use serde::Deserialize;
+    use serde_derive::Deserialize;
     #[derive(Debug, Deserialize)]
     #[allow(dead_code)]
     struct TypeWithUrl {

--- a/url/tests/wpt.rs
+++ b/url/tests/wpt.rs
@@ -64,7 +64,7 @@ macro_rules! println {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde_derive::Deserialize)]
 struct UrlTest {
     input: String,
     base: Option<String>,
@@ -72,7 +72,7 @@ struct UrlTest {
     result: UrlTestResult,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde_derive::Deserialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 enum UrlTestResult {
@@ -80,7 +80,7 @@ enum UrlTestResult {
     Fail(UrlTestFail),
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde_derive::Deserialize)]
 struct UrlTestOk {
     href: String,
     protocol: String,
@@ -94,19 +94,19 @@ struct UrlTestOk {
     hash: String,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde_derive::Deserialize)]
 struct UrlTestFail {
     failure: bool,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde_derive::Deserialize)]
 struct SetterTest {
     href: String,
     new_value: String,
     expected: SetterTestExpected,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde_derive::Deserialize)]
 struct SetterTestExpected {
     href: Option<String>,
     protocol: Option<String>,


### PR DESCRIPTION
This massively improves compile times by not forcing `serde` to depend on `serde_derive`. This allows many crates to start compiling much sooner, which ends up resulting in often quite massive compile time wins for real world projects.

In my case this PR reduced the build times of my project (clean, release) from 91.4s to 76.0s.