### PR TITLE
Fix roundtripping issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
             echo "Running tests with $sanitizer sanitizer..."
             export RUSTFLAGS="-Z sanitizer=$sanitizer"
             export RUSTDOCFLAGS="$RUSTFLAGS"
-            cargo +nightly test -Z build-std --target "$TARGET"
+            cargo +nightly test -Z build-std --target "$TARGET" --lib --tests
           done
 
   WASM:

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -151,16 +151,27 @@ impl<'a> Host<Cow<'a, str>> {
         };
 
         if input.find(is_invalid_host_char).is_some() {
-            Err(ParseError::InvalidDomainCharacter)
-        } else {
-            Ok(Host::Domain(
-                match utf8_percent_encode(&input, CONTROLS).into() {
-                    Cow::Owned(v) => Cow::Owned(v),
-                    // if we're borrowing, then we can return the original Cow
-                    Cow::Borrowed(_) => input,
-                },
-            ))
+            return Err(ParseError::InvalidDomainCharacter);
         }
+
+        // Call utf8_percent_encode and use the result.
+        // Note: This returns Cow::Borrowed for single-item results (either from input
+        // or from the static encoding table), and Cow::Owned for multi-item results.
+        // We cannot distinguish between "borrowed from input" vs "borrowed from static table"
+        // based on the Cow variant alone.
+        Ok(Host::Domain(
+            match utf8_percent_encode(&input, CONTROLS).into() {
+                Cow::Owned(v) => Cow::Owned(v),
+                // If we're borrowing, we need to check if it's the same as the input
+                Cow::Borrowed(v) => {
+                    if v == &*input {
+                        input // No encoding happened, reuse original
+                    } else {
+                        Cow::Owned(v.to_owned()) // Borrowed from static table, need to own it
+                    }
+                }
+            },
+        ))
     }
 
     pub(crate) fn into_owned(self) -> Host<String> {

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1383,3 +1383,12 @@ fn serde_error_message() {
         r#"relative URL without a base: "§invalid#+#*Ä" at line 1 column 25"#
     );
 }
+
+#[test]
+fn test_parse_url_with_single_byte_control_host() {
+    let input = "l://\x01:";
+
+    let url1 = Url::parse(input).unwrap();
+    let url2 = Url::parse(url1.as_str()).unwrap();
+    assert_eq!(url2, url1);
+}


### PR DESCRIPTION
This fixes a regression from #1021

```rust

#[test]
fn test_parse_url_with_single_byte_control_host() {
    let input = "l://\x01:";

    let url1 = Url::parse(input).unwrap();
    let url2 = Url::parse(url1.as_str()).unwrap();
    assert_eq!(url2, url1);
}
```

The problem is that the code at:
https://github.com/servo/rust-url/blob/22b925f93ad505a830f1089538a9ed6f5fd90612/url/src/host.rs#L157-L161
assumed Cow::Borrowed means no percent-encoding happened, but for single byte controls we do get a Cow::Borrowed from the [static encoding table](https://github.com/servo/rust-url/blob/22b925f93ad505a830f1089538a9ed6f5fd90612/percent_encoding/src/lib.rs#L74)