### PR TITLE
Test encoding of URL params

### DIFF
--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1392,3 +1392,25 @@ fn test_parse_url_with_single_byte_control_host() {
     let url2 = Url::parse(url1.as_str()).unwrap();
     assert_eq!(url2, url1);
 }
+
+#[test]
+fn magnet_roundtrip_parse() {
+    let url = Url::parse("magnet:?xt=urn:btmh:foo").unwrap();
+    assert_eq!(url.as_str(), "magnet:?xt=urn:btmh:foo");
+}
+
+#[test]
+fn magnet_roundtrip_append_pair() {
+    let mut url = Url::parse("magnet:").unwrap();
+    {
+        let mut query_pairs = url.query_pairs_mut();
+        query_pairs.append_pair("xt", "urn:btmh:foo");
+    }
+    assert_eq!(url.as_str(), "magnet:?xt=urn:btmh:foo");
+}
+
+#[test]
+fn magnet_roundtrip_parse_with_params() {
+    let url = Url::parse_with_params("magnet:", vec![("xt", "urn:btmh:foo")]).unwrap();
+    assert_eq!(url.as_str(), "magnet:?xt=urn:btmh:foo");
+}


### PR DESCRIPTION
Apparently `Url::parse` and `Url::parse_with_params` do different things leading to a different encoding and therefore string rep.

In `Url::parse`, `:` is preserved across params. That's not the case when using `parse_with_params` which internally uses `query_pairs_mut`.

I'm not sure which is correct in the general case. If i understand [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) they should be encoded in all cases, except when the protocol specifies it.

This PR only contains tests as i'm not familiar with url crate internals.