### PR TITLE
ci: update cargo-deny config, bump cargo-deny-action to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,8 +146,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
-      
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
   Result:
     name: Result
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,7 @@
 [licenses]
-allow-osi-fsf-free = "either"
-copyleft = "warn"
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Unicode-3.0",
+]
 private = { ignore = true }


### PR DESCRIPTION
Should fix the currently failing Audit CI job: https://github.com/servo/rust-url/actions/runs/20425030001/job/58683584498