### PR TITLE
Add FUNDING file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: servo
+open_collective: servo


### PR DESCRIPTION
This file copied from [the servo repo](https://github.com/servo/servo/blob/97aac6e70aaf903ae6863e16694fc7999fbd1d05/.github/FUNDING.yml) indicates that financial support for rust-url should be directed to the Servo project, via:

* [GitHub Sponsors](https://github.com/sponsors/servo), or
* [Open Collective](https://opencollective.com/servo)

See [GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).

This file is notably read by [ecosyste.ms](https://ecosyste.ms/), whose [Rust Ecosystem Fund](https://funds.ecosyste.ms/funds/rust) already has donations allocated to rust-url. Donations are made to the fund as a whole, which then distributes to popular crates based on some weighing function.

Although rust-url was originally created for use in Servo it is also used in many other projects and exits independently. However at this point rust-url is neither a mostly-single-person project, nor does it have its own formal structure capable of managing a budget. So if not Servo, it’s not clear to me where this money should go.

The status quo is that money allocated to rust-url by ecosyste.ms remains unclaimed. For February 2026, that amount is $93.67. [ecosyste.ms says](https://funds.ecosyste.ms/faq):

> Unclaimed funds are redistributed the following month.

… but the details of that are not clear to me. As of this writing the [Rust Ecosystem Fund](https://funds.ecosyste.ms/funds/rust) page shows almost $21k collected (presumably USD, over its lifetime) but less then $15k actually distributed to projects.