### PR TITLE
Add an "append_path" and "append_path_mut" functions to Url

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2760,14 +2760,15 @@ impl Url {
     ///
     /// This differs from [`Url::join`] in that it is insensitive to trailing slashes
     /// in the url and leading slashes in the passed string. See documentation of [`Url::join`] for discussion
-    /// of this subtlety. Also, this function cannot change any part of the Url other than the path.
+    /// of this subtlety. Also, this function cannot change any part of the Url other than the path. Note that
+    /// this clones the URL, so if you want to mutate the URL in place, use [`Url::append_path_mut`] instead.
     ///
     /// Examples:
     ///
     /// ```
     /// # use url::Url;
     /// let mut my_url = Url::parse("http://www.example.com/api/v1").unwrap();
-    /// my_url.append_path("system/status").unwrap();
+    /// my_url.append_path_mut("system/status").unwrap();
     /// assert_eq!(my_url.as_str(), "http://www.example.com/api/v1/system/status");
     /// ```
     ///
@@ -2776,7 +2777,36 @@ impl Url {
     /// Fails if the Url is cannot-be-a-base.
     #[allow(clippy::result_unit_err)]
     #[inline]
-    pub fn append_path(&mut self, path: impl AsRef<str>) -> Result<(), ()> {
+    pub fn append_path(&self, path: impl AsRef<str>) -> Result<Self, ()> {
+        let mut url = self.clone();
+        url.append_path_mut(path)?;
+        Ok(url)
+    }
+
+    /// Append path segments to the path of a Url, escaping if necessary.
+    ///
+    /// This differs from [`Url::join`] in that it is insensitive to trailing slashes
+    /// in the url and leading slashes in the passed string. See documentation of [`Url::join`] for discussion
+    /// of this subtlety. Also, this function cannot change any part of the Url other than the path.
+    ///
+    /// This mutates the URL in place. For a non-mutating variant that returns
+    /// a new `Url`, use [`Url::append_path`].
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use url::Url;
+    /// let mut my_url = Url::parse("http://www.example.com/api/v1").unwrap();
+    /// my_url.append_path_mut("system/status").unwrap();
+    /// assert_eq!(my_url.as_str(), "http://www.example.com/api/v1/system/status");
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Fails if the Url is cannot-be-a-base.
+    #[allow(clippy::result_unit_err)]
+    #[inline]
+    pub fn append_path_mut(&mut self, path: impl AsRef<str>) -> Result<(), ()> {
         // This fails if self is cannot-be-a-base but succeeds otherwise.
         let mut path_segments_mut = self.path_segments_mut()?;
 

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2756,6 +2756,38 @@ impl Url {
         Err(())
     }
 
+    /// Append path segments to the path of a Url, escaping if necesary.
+    /// Fails if the Url is cannot-be-a-base.
+    ///
+    /// This differs from Url::join in that it is insensitive to trailing slashes
+    /// in the url and leading slashes in the passed string. See documentation of Url::join for discussion
+    /// of this subtlety. Also, this function cannot change any part of the Url other than the path.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use url::Url;
+    /// let mut my_url = Url::parse("http://www.example.com/api/v1").unwrap();
+    /// my_url.append_path("system/status").unwrap();
+    /// assert_eq!(my_url.as_str(), "http://www.example.com/api/v1/system/status");
+    /// ```
+    #[inline]
+    pub fn append_path(&mut self, path: impl AsRef<str>) -> Result<(), ()> {
+        // This fails if self is cannot-be-a-base but succeeds otherwise.
+        let mut path_segments_mut = self.path_segments_mut()?;
+
+        // Remove the last segment if it is empty, this makes our code tolerate trailing `/`'s
+        path_segments_mut.pop_if_empty();
+
+        // Remove any leading `/` from the path we are appending, this makes our code tolerate leading `/`'s
+        let path = path.as_ref();
+        let path = path.strip_prefix('/').unwrap_or(path);
+        for segment in path.split('/') {
+            path_segments_mut.push(segment);
+        }
+        Ok(())
+    }
+
     // Private helper methods:
 
     #[inline]

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2757,7 +2757,6 @@ impl Url {
     }
 
     /// Append path segments to the path of a Url, escaping if necesary.
-    /// Fails if the Url is cannot-be-a-base.
     ///
     /// This differs from Url::join in that it is insensitive to trailing slashes
     /// in the url and leading slashes in the passed string. See documentation of Url::join for discussion
@@ -2771,6 +2770,9 @@ impl Url {
     /// my_url.append_path("system/status").unwrap();
     /// assert_eq!(my_url.as_str(), "http://www.example.com/api/v1/system/status");
     /// ```
+    ///
+    /// Fails if the Url is cannot-be-a-base.
+    #[allow(clippy::result_unit_err)]
     #[inline]
     pub fn append_path(&mut self, path: impl AsRef<str>) -> Result<(), ()> {
         // This fails if self is cannot-be-a-base but succeeds otherwise.

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2758,8 +2758,8 @@ impl Url {
 
     /// Append path segments to the path of a Url, escaping if necessary.
     ///
-    /// This differs from Url::join in that it is insensitive to trailing slashes
-    /// in the url and leading slashes in the passed string. See documentation of Url::join for discussion
+    /// This differs from [`Url::join`] in that it is insensitive to trailing slashes
+    /// in the url and leading slashes in the passed string. See documentation of [`Url::join`] for discussion
     /// of this subtlety. Also, this function cannot change any part of the Url other than the path.
     ///
     /// Examples:

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -2756,7 +2756,7 @@ impl Url {
         Err(())
     }
 
-    /// Append path segments to the path of a Url, escaping if necesary.
+    /// Append path segments to the path of a Url, escaping if necessary.
     ///
     /// This differs from Url::join in that it is insensitive to trailing slashes
     /// in the url and leading slashes in the passed string. See documentation of Url::join for discussion
@@ -2770,6 +2770,8 @@ impl Url {
     /// my_url.append_path("system/status").unwrap();
     /// assert_eq!(my_url.as_str(), "http://www.example.com/api/v1/system/status");
     /// ```
+    ///
+    /// # Errors
     ///
     /// Fails if the Url is cannot-be-a-base.
     #[allow(clippy::result_unit_err)]

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -542,6 +542,28 @@ fn append_empty_segment_then_mutate() {
 }
 
 #[test]
+fn append_path_returns_new_url() {
+    let url = Url::parse("http://www.example.com/api/v1/").unwrap();
+
+    let appended = url.append_path("/system/status").unwrap();
+
+    assert_eq!(url.as_str(), "http://www.example.com/api/v1/");
+    assert_eq!(
+        appended.as_str(),
+        "http://www.example.com/api/v1/system/status"
+    );
+}
+
+#[test]
+fn append_path_and_append_path_mut_fail_for_cannot_be_a_base() {
+    let url = Url::parse("mailto:test@example.net").unwrap();
+    assert!(url.append_path("x").is_err());
+
+    let mut url = Url::parse("mailto:test@example.net").unwrap();
+    assert!(url.append_path_mut("x").is_err());
+}
+
+#[test]
 /// https://github.com/servo/rust-url/issues/243
 fn test_set_host() {
     let mut url = Url::parse("https://example.net/hello").unwrap();
@@ -1398,36 +1420,36 @@ fn test_parse_url_with_single_byte_control_host() {
 /// https://github.com/servo/rust-url/issues/333
 fn test_append_path() {
     // append_path behaves as expected when path is `/` regardless of trailing & leading slashes
-    let mut url = Url::parse("http://test.com").unwrap();
-    url.append_path("/a/b/c").unwrap();
+    let url = Url::parse("http://test.com").unwrap();
+    let url = url.append_path("/a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/a/b/c");
 
-    let mut url = Url::parse("http://test.com").unwrap();
-    url.append_path("a/b/c").unwrap();
+    let url = Url::parse("http://test.com").unwrap();
+    let url = url.append_path("a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/a/b/c");
 
-    let mut url = Url::parse("http://test.com/").unwrap();
-    url.append_path("/a/b/c").unwrap();
+    let url = Url::parse("http://test.com/").unwrap();
+    let url = url.append_path("/a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/a/b/c");
 
-    let mut url = Url::parse("http://test.com/").unwrap();
-    url.append_path("a/b/c").unwrap();
+    let url = Url::parse("http://test.com/").unwrap();
+    let url = url.append_path("a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/a/b/c");
 
     // append_path behaves as expected when path is `/api/v1` regardless of trailing & leading slashes
-    let mut url = Url::parse("http://test.com/api/v1").unwrap();
-    url.append_path("/a/b/c").unwrap();
+    let url = Url::parse("http://test.com/api/v1").unwrap();
+    let url = url.append_path("/a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
 
-    let mut url = Url::parse("http://test.com/api/v1").unwrap();
-    url.append_path("a/b/c").unwrap();
+    let url = Url::parse("http://test.com/api/v1").unwrap();
+    let url = url.append_path("a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
 
-    let mut url = Url::parse("http://test.com/api/v1/").unwrap();
-    url.append_path("/a/b/c").unwrap();
+    let url = Url::parse("http://test.com/api/v1/").unwrap();
+    let url = url.append_path("/a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
 
-    let mut url = Url::parse("http://test.com/api/v1/").unwrap();
-    url.append_path("a/b/c").unwrap();
+    let url = Url::parse("http://test.com/api/v1/").unwrap();
+    let url = url.append_path("a/b/c").unwrap();
     assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
 }

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1392,3 +1392,42 @@ fn test_parse_url_with_single_byte_control_host() {
     let url2 = Url::parse(url1.as_str()).unwrap();
     assert_eq!(url2, url1);
 }
+
+#[test]
+/// append_path is an alternative to Url::join addressing issues described in
+/// https://github.com/servo/rust-url/issues/333
+fn test_append_path() {
+    // append_path behaves as expected when path is `/` regardless of trailing & leading slashes
+    let mut url = Url::parse("http://test.com").unwrap();
+    url.append_path("/a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/a/b/c");
+
+    let mut url = Url::parse("http://test.com").unwrap();
+    url.append_path("a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/a/b/c");
+
+    let mut url = Url::parse("http://test.com/").unwrap();
+    url.append_path("/a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/a/b/c");
+
+    let mut url = Url::parse("http://test.com/").unwrap();
+    url.append_path("a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/a/b/c");
+
+    // append_path behaves as expected when path is `/api/v1` regardless of trailing & leading slashes
+    let mut url = Url::parse("http://test.com/api/v1").unwrap();
+    url.append_path("/a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
+
+    let mut url = Url::parse("http://test.com/api/v1").unwrap();
+    url.append_path("a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
+
+    let mut url = Url::parse("http://test.com/api/v1/").unwrap();
+    url.append_path("/a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
+
+    let mut url = Url::parse("http://test.com/api/v1/").unwrap();
+    url.append_path("a/b/c").unwrap();
+    assert_eq!(url.as_str(), "http://test.com/api/v1/a/b/c");
+}


### PR DESCRIPTION
This PR replaces https://github.com/servo/rust-url/pull/934 with the following changes:

1. I rebased the branch from @cbeck88 on the latest `main`.
2. I addressed the review comments from @carlocorradini regarding the doc comments. I also changed the reference to other doc items to use proper links.
3. I renamed the method to `append_path_mut` and introduced a new `append_path` that takes `&self` and returns `Result<Self, ()>` so that it's a true drop-in replacement for `Url:join`. The requires cloning the url. I think this is acceptable but it the maintainers disagree I can revert this change.