### PR TITLE
fix: handling of leading slashes when setting pathname for file url

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1368,7 +1368,7 @@ impl Parser<'_> {
                 break;
             }
         }
-        if scheme_type.is_file() {
+        if scheme_type.is_file() && self.context != Context::Setter {
             // while url’s path’s size is greater than 1
             // and url’s path[0] is the empty string,
             // validation error, remove the first item from url’s path.

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -38,9 +38,6 @@
 <non-spec:/.//p> set hostname to <>
 <foo:///some/path> set pathname to <>
 <file:///var/log/system.log> set href to <http://0300.168.0xF0>
-<file://monkey/> set pathname to <\\\\>
-<file:///unicorn> set pathname to <//\\/>
-<file:///unicorn> set pathname to <//monkey/..//>
 <non-spec:/> set pathname to </.//p>
 <non-spec:/> set pathname to </..//p>
 <non-spec:/> set pathname to <//p>


### PR DESCRIPTION
This change skips the normalization of the leading `//` in path in `Context::Setter`, which fixes #1118