### PR TITLE
make idna an optional dependency

### DIFF
--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -27,14 +27,14 @@ wasm-bindgen-test = "0.3"
 
 [dependencies]
 form_urlencoded = { version = "1.2.2", path = "../form_urlencoded", default-features = false, features = ["alloc"] }
-idna = { version = "1.1.0", path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
+idna = { version = "1.1.0", optional = true, path = "../idna", default-features = false, features = ["alloc", "compiled_data"] }
 percent-encoding = { version = "2.3.2", path = "../percent_encoding", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, default-features = false }
 serde_derive = { version = "1.0", optional = true, default-features = false }
 
 [features]
-default = ["std"]
-std = ["idna/std", "percent-encoding/std", "form_urlencoded/std", "serde?/std"]
+default = ["std", "idna"]
+std = ["idna?/std", "percent-encoding/std", "form_urlencoded/std", "serde?/std"]
 
 # Enable to use the #[debugger_visualizer] attribute. This feature requires Rust >= 1.71.
 debugger_visualizer = []

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -97,16 +97,38 @@ impl<'a> Host<Cow<'a, str>> {
             return parse_ipv6addr(&input[1..input.len() - 1]).map(Host::Ipv6);
         }
         let domain: Cow<'_, [u8]> = percent_decode(input.as_bytes()).into();
-        let domain: Cow<'a, [u8]> = match domain {
-            Cow::Owned(v) => Cow::Owned(v),
-            // if borrowed then we can use the original cow
-            Cow::Borrowed(_) => match input {
-                Cow::Borrowed(input) => Cow::Borrowed(input.as_bytes()),
-                Cow::Owned(input) => Cow::Owned(input.into_bytes()),
-            },
-        };
 
-        let domain = idna::domain_to_ascii_from_cow(domain, idna::AsciiDenyList::URL)?;
+        let domain = {
+            #[cfg(feature = "idna")]
+            {
+                let domain_bytes: Cow<'a, [u8]> = match domain {
+                    Cow::Owned(v) => Cow::Owned(v),
+                    // if borrowed then we can use the original cow
+                    Cow::Borrowed(_) => match input {
+                        Cow::Borrowed(input) => Cow::Borrowed(input.as_bytes()),
+                        Cow::Owned(input) => Cow::Owned(input.into_bytes()),
+                    },
+                };
+                idna::domain_to_ascii_from_cow(domain_bytes, idna::AsciiDenyList::URL)?
+            }
+            #[cfg(not(feature = "idna"))]
+            {
+                match domain {
+                    Cow::Owned(vec) => String::from_utf8(vec)
+                        .map(Cow::Owned)
+                        .map_err(|_| ParseError::InvalidDomainCharacter),
+                    // if borrowed then we can use the original cow
+                    Cow::Borrowed(_) => match input {
+                        Cow::Borrowed(s) => std::str::from_utf8(s.as_bytes())
+                            .map(Cow::Borrowed)
+                            .map_err(|_| ParseError::InvalidDomainCharacter),
+                        Cow::Owned(s) => String::from_utf8(s.into_bytes())
+                            .map(Cow::Owned)
+                            .map_err(|_| ParseError::InvalidDomainCharacter),
+                    },
+                }?
+            }
+        };
 
         if domain.is_empty() {
             return Err(ParseError::EmptyHost);

--- a/url/src/origin.rs
+++ b/url/src/origin.rs
@@ -90,17 +90,15 @@ impl Origin {
 
     /// <https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin>
     pub fn unicode_serialization(&self) -> String {
-        match *self {
+        match self {
             Self::Opaque(_) => "null".to_owned(),
-            Self::Tuple(ref scheme, ref host, port) => {
-                let host = match *host {
-                    Host::Domain(ref domain) => {
-                        let (domain, _errors) = idna::domain_to_unicode(domain);
-                        Host::Domain(domain)
-                    }
+            Self::Tuple(scheme, host, port) => {
+                let host = match host {
+                    #[cfg(feature = "idna")]
+                    Host::Domain(domain) => Host::Domain(idna::domain_to_unicode(&domain).0),
                     _ => host.clone(),
                 };
-                if default_port(scheme) == Some(port) {
+                if default_port(&scheme) == Some(*port) {
                     format!("{scheme}://{host}")
                 } else {
                     format!("{scheme}://{host}:{port}")

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -98,6 +98,7 @@ simple_enum_error! {
     Overflow => "URLs more than 4 GB are not supported",
 }
 
+#[cfg(feature = "idna")]
 impl From<::idna::Errors> for ParseError {
     fn from(_: ::idna::Errors) -> Self {
         Self::IdnaError

--- a/url/src/quirks.rs
+++ b/url/src/quirks.rs
@@ -70,9 +70,15 @@ pub fn domain_to_ascii(domain: &str) -> String {
 /// <https://url.spec.whatwg.org/#dom-url-domaintounicode>
 pub fn domain_to_unicode(domain: &str) -> String {
     match Host::parse(domain) {
-        Ok(Host::Domain(ref domain)) => {
-            let (unicode, _errors) = idna::domain_to_unicode(domain);
-            unicode
+        Ok(Host::Domain(domain)) => {
+            #[cfg(feature = "idna")]
+            {
+                idna::domain_to_unicode(&domain).0
+            }
+            #[cfg(not(feature = "idna"))]
+            {
+                domain
+            }
         }
         _ => String::new(),
     }


### PR DESCRIPTION
For use cases where domain names are already ascii, the compile-time hit of the idna dependency and the unnecessary processing can be avoided by disabling the optional feature