### PR TITLE
Fix #1123

### DIFF
--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -383,32 +383,6 @@ impl Url {
         url
     }
 
-    /// https://url.spec.whatwg.org/#potentially-strip-trailing-spaces-from-an-opaque-path
-    fn strip_trailing_spaces_from_opaque_path(&mut self) {
-        if !self.cannot_be_a_base() {
-            return;
-        }
-
-        if self.fragment_start.is_some() {
-            return;
-        }
-
-        if self.query_start.is_some() {
-            return;
-        }
-
-        let trailing_space_count = self
-            .serialization
-            .chars()
-            .rev()
-            .take_while(|c| *c == ' ')
-            .count();
-
-        let start = self.serialization.len() - trailing_space_count;
-
-        self.serialization.truncate(start);
-    }
-
     /// Parse a string as an URL, with this URL as the base URL.
     ///
     /// The inverse of this is [`make_relative`].
@@ -1591,7 +1565,6 @@ impl Url {
             self.mutate(|parser| parser.parse_fragment(parser::Input::new_no_trim(input)))
         } else {
             self.fragment_start = None;
-            self.strip_trailing_spaces_from_opaque_path();
         }
     }
 
@@ -1657,9 +1630,6 @@ impl Url {
             });
         } else {
             self.query_start = None;
-            if fragment.is_none() {
-                self.strip_trailing_spaces_from_opaque_path();
-            }
         }
 
         self.restore_already_parsed_fragment(fragment);
@@ -1758,6 +1728,13 @@ impl Url {
     /// url.set_path("api/some%20comments");
     /// assert_eq!(url.as_str(), "https://example.com/api/some%20comments");
     /// assert_eq!(url.path(), "/api/some%20comments");
+    ///
+    /// // `set_path` will encode leading `/` and trailing ` ` in cannot-be-a-base paths.
+    /// let mut url = Url::parse("non-special:  ?")?;
+    /// assert_eq!(url.path(), " %20");
+    /// url.set_query(None);
+    /// url.set_path("/  ");
+    /// assert_eq!(url.path(), "%2F %20");
     ///
     /// # Ok(())
     /// # }

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1431,6 +1431,10 @@ impl Parser<'_> {
                 Some(('?', _)) | Some(('#', _)) if self.context == Context::UrlParser => {
                     return input_before_c
                 }
+                Some((' ', _)) if input.starts_with('?') || input.starts_with('#') || input.is_empty() => {
+                    self.serialization.push_str("%20");
+                    return input;
+                }
                 Some((c, utf8_c)) => {
                     self.check_url_code_point(c, &input);
                     self.serialization

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -46,11 +46,6 @@
 <non-spec:/> set pathname to <//p>
 <non-spec:/.//> set pathname to <p>
 <file:///w|/m>
-<non-special:opaque  ?hi>
-<non-special:opaque  #hi>
-<non-special:opaque \t\t  \t#hi>
-<non-special:opaque \t\t  #hi>
-<non-special:opaque\t\t  \r #hi>
 <foo://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
 <wss://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
 <///test> against <http://example.org/>
@@ -62,12 +57,4 @@
 <///example.org/../path/../../path> against <http://example.org/>
 </\\//\\/a/../> against <file:///>
 <a:/> set pathname to <\u{0}\u{1}\t\n\r\u{1f} !\"#$%&\'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~\u{7f}\u{80}\u{81}\u{c9}\u{e9}>
-<data:space                                                                                                                                  #fragment> set hash to <>
-<sc:space    #fragment> set hash to <>
-<data:space  ?query#fragment> set hash to <>
-<sc:space  ?query#fragment> set hash to <>
-<data:space ?query> set search to <>
-<sc:space ?query> set search to <>
-<data:space  ?query#fragment> set search to <>
-<sc:space  ?query#fragment> set search to <>
 <https://domain.com:3000> set port to <\n\n\t\t>

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -68,17 +68,6 @@ fn test_relative_empty() {
 }
 
 #[test]
-fn test_strip_trailing_spaces_from_opaque_path() {
-    let mut url: Url = "data:space   ?query".parse().unwrap();
-    url.set_query(None);
-    assert_eq!(url.as_str(), "data:space");
-
-    let mut url: Url = "data:space   #hash".parse().unwrap();
-    url.set_fragment(None);
-    assert_eq!(url.as_str(), "data:space");
-}
-
-#[test]
 fn test_set_empty_host() {
     let mut base: Url = "moz://foo:bar@servo/baz".parse().unwrap();
     base.set_username("").unwrap();


### PR DESCRIPTION
Correct `a:  ?` to parse as `a: %20?` and also make setting cannot-be-a-base paths to end in a space literal to replace that space literal with a `%20`.
