### PR TITLE
Fix URL parsing for scheme-relative paths with multiple slashes

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -774,6 +774,9 @@ impl Parser<'_> {
                     debug_assert!(base_url.byte_at(scheme_end) == b':');
                     self.serialization
                         .push_str(base_url.slice(..scheme_end + 1));
+                    if scheme_type.is_special() {
+                        return self.after_double_slash(remaining, scheme_type, scheme_end);
+                    }
                     if let Some(after_prefix) = input.split_prefix("//") {
                         return self.after_double_slash(after_prefix, scheme_type, scheme_end);
                     }

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -53,13 +53,6 @@
 <non-special:opaque\t\t  \r #hi>
 <foo://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
 <wss://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
-<///test> against <http://example.org/>
-<///\\//\\//test> against <http://example.org/>
-<///example.org/path> against <http://example.org/>
-<///example.org/../path> against <http://example.org/>
-<///example.org/../../> against <http://example.org/>
-<///example.org/../path/../../> against <http://example.org/>
-<///example.org/../path/../../path> against <http://example.org/>
 </\\//\\/a/../> against <file:///>
 <a:/> set pathname to <\u{0}\u{1}\t\n\r\u{1f} !\"#$%&\'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~\u{7f}\u{80}\u{81}\u{c9}\u{e9}>
 <data:space                                                                                                                                  #fragment> set hash to <>


### PR DESCRIPTION
## Summary

When a relative URL starts with more than two slashes (e.g., `///test`) and the base URL has a special scheme (http, https, ws, wss, ftp), the parser now correctly consumes all leading slashes before parsing the authority, matching the URL spec special authority slashes state.

Previously, only two slashes were consumed via split_prefix, leaving the remaining slash to be parsed as part of the authority, which caused an empty host error for inputs like `///test` with base `http://example.org/`.

This fixes the WPT test cases for scheme-relative paths starting with multiple slashes against special-scheme base URLs.

## Test Plan

- All existing tests pass (12808 WPT tests, plus unit tests)
- Removed 7 entries from expected_failures.txt that are now correctly handled
- Verified the fix against the WPT test data:
  - new URL("///test", "http://example.org/") now returns http://test/ (was throwing)
  - new URL("///example.org/path", "http://example.org/") now returns http://example.org/path
  - new URL("///\\\\//\\\\//test", "http://example.org/") now returns http://test/

## AI Assistance Disclosure

This PR was created with assistance from an AI coding assistant. The AI identified the bug, proposed the fix, and helped write the code. All changes were reviewed and verified by a human.