### PR TITLE
Collapse all leading slashes for special relative URLs

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -774,6 +774,14 @@ impl Parser<'_> {
                     debug_assert!(base_url.byte_at(scheme_end) == b':');
                     self.serialization
                         .push_str(base_url.slice(..scheme_end + 1));
+                    // A special URL enters the "special authority ignore slashes
+                    // state", which skips *all* leading slashes and backslashes
+                    // before the authority (e.g. "///host" resolves to host
+                    // "host"). A non-special URL only treats the initial "//" as
+                    // the authority delimiter; any further slashes are the path.
+                    if scheme_type.is_special() {
+                        return self.after_double_slash(remaining, scheme_type, scheme_end);
+                    }
                     if let Some(after_prefix) = input.split_prefix("//") {
                         return self.after_double_slash(after_prefix, scheme_type, scheme_end);
                     }

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -53,13 +53,6 @@
 <non-special:opaque\t\t  \r #hi>
 <foo://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
 <wss://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
-<///test> against <http://example.org/>
-<///\\//\\//test> against <http://example.org/>
-<///example.org/path> against <http://example.org/>
-<///example.org/../path> against <http://example.org/>
-<///example.org/../../> against <http://example.org/>
-<///example.org/../path/../../> against <http://example.org/>
-<///example.org/../path/../../path> against <http://example.org/>
 </\\//\\/a/../> against <file:///>
 <a:/> set pathname to <\u{0}\u{1}\t\n\r\u{1f} !\"#$%&\'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~\u{7f}\u{80}\u{81}\u{c9}\u{e9}>
 <data:space                                                                                                                                  #fragment> set hash to <>


### PR DESCRIPTION
## Summary

Special-scheme URLs with multiple leading slashes (e.g. `///test`) were parsed
incorrectly and failed with `EmptyHost`. Resolving `new URL("///test", "http://example.org/")`
returned an error instead of `http://test/`, disagreeing with Chrome, Firefox,
Node and Bun.

## Fix

When resolving a relative reference against a special base URL (`http`, `https`,
`ws`, `wss`, `ftp`), the WHATWG URL standard's *special authority ignore slashes
state* skips **all** leading slashes and backslashes before the authority.
`parse_relative` previously stripped only the initial `//` and parsed the
remainder as the authority, so `///test` produced an authority of `/test` whose
leading slash yielded an empty host.

The fix branches on `scheme_type.is_special()`: a special URL now consistently
consumes every leading slash/backslash before the authority, while a non-special
URL keeps treating only the first `//` as the authority delimiter and the rest as
the path.

## Test

No new fixtures were needed — the upstream WPT data in `url/tests/urltestdata.json`
already encodes the spec-mandated results. These seven `///`-prefixed cases (base
`http://example.org/`) were removed from `url/tests/expected_failures.txt` and now
pass:

| input | resolved href |
|-------|---------------|
| `///test` | `http://test/` |
| `///\//\//test` | `http://test/` |
| `///example.org/path` | `http://example.org/path` |
| `///example.org/../path` | `http://example.org/path` |
| `///example.org/../../` | `http://example.org/` |
| `///example.org/../path/../../` | `http://example.org/` |
| `///example.org/../path/../../path` | `http://example.org/path` |

The full `url_wpt` conformance suite passes with no other regressions (the harness
also flags "unexpected success", confirming these cases genuinely flipped from
failing to passing).

## Reference

This is also the upstream cause of downstream issues such as
[denoland/deno#35172](https://github.com/denoland/deno/issues/35172), since Deno
parses URLs through this crate.
