### PR TITLE
fix: parse relative URLs with multiple leading slashes for special schemes

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -774,6 +774,9 @@ impl Parser<'_> {
                     debug_assert!(base_url.byte_at(scheme_end) == b':');
                     self.serialization
                         .push_str(base_url.slice(..scheme_end + 1));
+                    if scheme_type.is_special() {
+                        return self.after_double_slash(remaining, scheme_type, scheme_end);
+                    }
                     if let Some(after_prefix) = input.split_prefix("//") {
                         return self.after_double_slash(after_prefix, scheme_type, scheme_end);
                     }

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -53,13 +53,6 @@
 <non-special:opaque\t\t  \r #hi>
 <foo://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
 <wss://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
-<///test> against <http://example.org/>
-<///\\//\\//test> against <http://example.org/>
-<///example.org/path> against <http://example.org/>
-<///example.org/../path> against <http://example.org/>
-<///example.org/../../> against <http://example.org/>
-<///example.org/../path/../../> against <http://example.org/>
-<///example.org/../path/../../path> against <http://example.org/>
 </\\//\\/a/../> against <file:///>
 <a:/> set pathname to <\u{0}\u{1}\t\n\r\u{1f} !\"#$%&\'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~\u{7f}\u{80}\u{81}\u{c9}\u{e9}>
 <data:space                                                                                                                                  #fragment> set hash to <>


### PR DESCRIPTION
## What's wrong

When a relative URL starts with more than two slashes (e.g. `///test`) and the base URL has a special scheme (`http`, `https`, `ws`, `wss`, `ftp`), the parser throws an error instead of correctly parsing it.

```rust
Url::options().base_url(Some(&Url::parse("http://example.org/").unwrap()))
    .parse("///test")
    .unwrap()
// Expected: http://test/
// Actual: Err(EmptyHost)
```

This matches Chrome, Firefox, Node, and Bun behavior. The URL spec's special authority slashes state says all leading slashes should be consumed before parsing the authority.

## What this does

In `parse_relative`, when we have a base URL with a special scheme, we now route directly to `after_double_slash` with the remaining input, which correctly handles multiple leading slashes. The existing `split_prefix("//")` path is kept for non-special schemes.

Also removed 7 entries from `expected_failures.txt` that now pass correctly:
- `///test` against `http://example.org/`
- `///example.org/path` against `http://example.org/`
- and 5 more variants

## Test plan

- All existing WPT tests should pass
- The 7 removed expected failures should now be correct
- Verified against the WPT test data for scheme-relative paths with multiple slashes

## Context

This was previously reported as denoland/deno#35172 where `new URL("///test", "http://example.org")` throws in Deno but works in all other browsers and runtimes.
