### PR TITLE
Only skip trailing-slash removal for drive letters on file: URLs

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1320,7 +1320,11 @@ impl Parser<'_> {
                     debug_assert!(self.serialization.as_bytes()[segment_start - 1] == b'/');
                     self.serialization.truncate(segment_start);
                     if self.serialization.ends_with('/')
-                        && Parser::last_slash_can_be_removed(&self.serialization, path_start)
+                        && Parser::last_slash_can_be_removed(
+                            scheme_type,
+                            &self.serialization,
+                            path_start,
+                        )
                     {
                         self.serialization.pop();
                     }
@@ -1380,13 +1384,21 @@ impl Parser<'_> {
         input
     }
 
-    fn last_slash_can_be_removed(serialization: &str, path_start: usize) -> bool {
+    fn last_slash_can_be_removed(
+        scheme_type: SchemeType,
+        serialization: &str,
+        path_start: usize,
+    ) -> bool {
         let url_before_segment = &serialization[..serialization.len() - 1];
         if let Some(segment_before_start) = url_before_segment.rfind('/') {
             // Do not remove the root slash
             segment_before_start >= path_start
-                // Or a windows drive letter slash
-                && !path_starts_with_windows_drive_letter(&serialization[segment_before_start..])
+                // Or a windows drive letter slash. This exemption only applies to
+                // file: URLs: https://url.spec.whatwg.org/#pop-a-urls-path
+                && !(scheme_type.is_file()
+                    && path_starts_with_windows_drive_letter(
+                        &serialization[segment_before_start..],
+                    ))
         } else {
             false
         }

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1351,6 +1351,41 @@ fn test_file_with_drive_and_path() {
     assert_eq!(url2.to_string(), "file:///p:/a");
 }
 
+#[test]
+/// https://github.com/servo/rust-url/issues/1130
+/// A path segment that looks like a Windows drive letter (e.g. "C:" or "C|")
+/// is only special for file: URLs. For any other scheme it is an ordinary
+/// segment, so ".." must pop it.
+fn test_join_dotdot_pops_drive_letter_lookalike_for_non_file_scheme() {
+    let url = url::Url::parse("abc://x/y/z/C:/").unwrap();
+    let joined = url.join("..").unwrap();
+    assert_eq!(joined.as_str(), "abc://x/y/z/");
+
+    // Special (but non-file) scheme hits the same code path.
+    let url = url::Url::parse("http://x/y/z/C:/").unwrap();
+    let joined = url.join("..").unwrap();
+    assert_eq!(joined.as_str(), "http://x/y/z/");
+
+    // The "C|" (pipe) form is affected too.
+    let url = url::Url::parse("abc://x/y/z/C|/").unwrap();
+    let joined = url.join("..").unwrap();
+    assert_eq!(joined.as_str(), "abc://x/y/z/");
+}
+
+#[test]
+/// Companion to test_join_dotdot_pops_drive_letter_lookalike_for_non_file_scheme:
+/// file: URLs must keep popping a trailing ordinary segment while still
+/// refusing to pop past a Windows drive letter root.
+fn test_join_dotdot_keeps_drive_letter_guard_for_file_scheme() {
+    let url = url::Url::parse("file:///c:/foo/").unwrap();
+    let joined = url.join("..").unwrap();
+    assert_eq!(joined.as_str(), "file:///c:/");
+
+    let url = url::Url::parse("file:///c:/").unwrap();
+    let joined = url.join("..").unwrap();
+    assert_eq!(joined.as_str(), "file:///c:/");
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn issue_864() {


### PR DESCRIPTION
last_slash_can_be_removed() refused to drop a trailing slash whenever the
previous path segment looked like a Windows drive letter (C: or C|), even
outside file: URLs. Per the spec (https://url.spec.whatwg.org/#pop-a-urls-path)
this exemption only applies when url's scheme is "file" - shorten_path and
pop_path already gate the same check on scheme_type.is_file(), this was the
one sibling that didn't.

Fixes #1130

    Url::parse("abc://x/y/z/C:/").unwrap().join("..").unwrap()
    // was "abc://x/y/z/C:/", now "abc://x/y/z/"

Added tests cover non-file special and non-special schemes, the C| form,
and a companion case confirming file: URLs keep the existing drive-letter
guard.
