### PR TITLE
fix percent-encode of caret in path (#1140)

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -19,8 +19,12 @@ use percent_encoding::{percent_encode, utf8_percent_encode, AsciiSet, CONTROLS};
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
 
+/// https://url.spec.whatwg.org/#query-percent-encode-set
+const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
+const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');
+
 /// https://url.spec.whatwg.org/#path-percent-encode-set
-const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
+const PATH: &AsciiSet = &QUERY.add(b'?').add(b'^').add(b'`').add(b'{').add(b'}');
 
 /// https://url.spec.whatwg.org/#userinfo-percent-encode-set
 pub(crate) const USERINFO: &AsciiSet = &PATH
@@ -32,7 +36,6 @@ pub(crate) const USERINFO: &AsciiSet = &PATH
     .add(b'[')
     .add(b'\\')
     .add(b']')
-    .add(b'^')
     .add(b'|');
 
 pub(crate) const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
@@ -40,10 +43,6 @@ pub(crate) const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
 // The backslash (\) character is treated as a path separator in special URLs
 // so it needs to be additionally escaped in that case.
 pub(crate) const SPECIAL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'\\');
-
-// https://url.spec.whatwg.org/#query-state
-const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
-const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');
 
 pub type ParseResult<T> = Result<T, ParseError>;
 

--- a/url/tests/expected_failures.txt
+++ b/url/tests/expected_failures.txt
@@ -51,8 +51,6 @@
 <non-special:opaque \t\t  \t#hi>
 <non-special:opaque \t\t  #hi>
 <non-special:opaque\t\t  \r #hi>
-<foo://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
-<wss://host/ !\"$%&\'()*+,-./:;<=>@[\\]^_`{|}~>
 <///test> against <http://example.org/>
 <///\\//\\//test> against <http://example.org/>
 <///example.org/path> against <http://example.org/>
@@ -61,7 +59,6 @@
 <///example.org/../path/../../> against <http://example.org/>
 <///example.org/../path/../../path> against <http://example.org/>
 </\\//\\/a/../> against <file:///>
-<a:/> set pathname to <\u{0}\u{1}\t\n\r\u{1f} !\"#$%&\'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~\u{7f}\u{80}\u{81}\u{c9}\u{e9}>
 <data:space                                                                                                                                  #fragment> set hash to <>
 <sc:space    #fragment> set hash to <>
 <data:space  ?query#fragment> set hash to <>

--- a/url/tests/unit.rs
+++ b/url/tests/unit.rs
@@ -1392,3 +1392,23 @@ fn test_parse_url_with_single_byte_control_host() {
     let url2 = Url::parse(url1.as_str()).unwrap();
     assert_eq!(url2, url1);
 }
+
+#[test]
+fn test_path_percent_encode() {
+    let url = Url::parse("http://localhost/a b").unwrap();
+    assert_eq!(url.path(), "/a%20b");
+    let url = Url::parse("http://localhost/a\"b").unwrap();
+    assert_eq!(url.path(), "/a%22b");
+    let url = Url::parse("http://localhost/a<b").unwrap();
+    assert_eq!(url.path(), "/a%3Cb");
+    let url = Url::parse("http://localhost/a>b").unwrap();
+    assert_eq!(url.path(), "/a%3Eb");
+    let url = Url::parse("http://localhost/a^b").unwrap();
+    assert_eq!(url.path(), "/a%5Eb");
+    let url = Url::parse("http://localhost/a`b").unwrap();
+    assert_eq!(url.path(), "/a%60b");
+    let url = Url::parse("http://localhost/a{b").unwrap();
+    assert_eq!(url.path(), "/a%7Bb");
+    let url = Url::parse("http://localhost/a}b").unwrap();
+    assert_eq!(url.path(), "/a%7Db");
+}


### PR DESCRIPTION
This commit adds the caret symbol U+005E (`^`) to the path percent-encode set, as required by the WHATWG spec. This fixes percent-encoding of carets in the path during parsing.

This commit adds a test for all URL codepoints that are part of the path percent-encode set, except for `?` and `#` which end parsing of the path.

Closes #1140