### PR TITLE
perf: speed up URL parsing and IDNA ToASCII

### DIFF
--- a/idna/Cargo.toml
+++ b/idna/Cargo.toml
@@ -34,6 +34,7 @@ assert_matches = "1.3"
 bencher = "0.1"
 tester = "0.9"
 serde_json = "1.0"
+gungraun = "0.19.4"
 
 [dependencies]
 utf8_iter = "1.0.4"
@@ -42,6 +43,10 @@ idna_adapter = "1"
 
 [[bench]]
 name = "all"
+harness = false
+
+[[bench]]
+name = "all_gungraun"
 harness = false
 
 [package.metadata.docs.rs]

--- a/idna/benches/all_gungraun.rs
+++ b/idna/benches/all_gungraun.rs
@@ -1,0 +1,50 @@
+//! Callgrind-based instruction-count benchmarks for idna, mirroring the cases
+//! in `all.rs`. Run with `cargo bench -p idna --bench all_gungraun` (requires
+//! Valgrind and a matching `gungraun-runner`).
+
+#![allow(deprecated)]
+
+use std::borrow::Cow;
+use std::hint::black_box;
+
+use gungraun::{library_benchmark, library_benchmark_group, main};
+
+use idna::{AsciiDenyList, Config, Errors};
+
+#[library_benchmark]
+#[bench::puny_label("abc.xn--mgbcm")]
+#[bench::ascii("example.com")]
+#[bench::merged_label("Beispiel.xn--vermgensberater-ctb")]
+fn to_unicode(encoded: &str) -> (String, Result<(), Errors>) {
+    Config::default().to_unicode(black_box(encoded))
+}
+
+#[library_benchmark]
+#[bench::already_puny_label("abc.xn--mgbcm")]
+#[bench::puny_label("abc.ابج")]
+#[bench::simple("example.com")]
+#[bench::merged("beispiel.vermögensberater")]
+fn to_ascii(encoded: &str) -> Result<String, Errors> {
+    Config::default().to_ascii(black_box(encoded))
+}
+
+#[library_benchmark]
+#[bench::plain("example.com".as_bytes())]
+#[bench::hyphen("hyphenated-example.com".as_bytes())]
+#[bench::leading_digit("1test.example".as_bytes())]
+#[bench::unicode_mixed("مثال.example".as_bytes())]
+#[bench::punycode_mixed("xn--mgbh0fb.example".as_bytes())]
+#[bench::unicode_ltr("නම.උදාහරණ".as_bytes())]
+#[bench::punycode_ltr("xn--r0co.xn--ozc8dl2c3bxd".as_bytes())]
+#[bench::unicode_rtl("الاسم.مثال".as_bytes())]
+#[bench::punycode_rtl("xn--mgba0b1dh.xn--mgbh0fb".as_bytes())]
+fn to_ascii_cow(encoded: &[u8]) -> Result<Cow<'_, str>, Errors> {
+    idna::domain_to_ascii_cow(black_box(encoded), AsciiDenyList::URL)
+}
+
+library_benchmark_group!(
+    name = benches;
+    benchmarks = to_unicode, to_ascii, to_ascii_cow
+);
+
+main!(library_benchmark_groups = benches);

--- a/idna/src/uts46.rs
+++ b/idna/src/uts46.rs
@@ -182,6 +182,46 @@ fn is_passthrough_ascii_label(label: &[u8]) -> bool {
     }
 }
 
+/// Like `is_passthrough_ascii_label`, but for labels whose only disqualifying
+/// feature is a leading ASCII digit. A leading digit is only invalid in a bidi
+/// domain name (Bidi rule 1), so such a label may be passed through when the
+/// domain name is known not to be bidi.
+#[inline(always)]
+fn is_leading_digit_passthrough_ascii_label(label: &[u8]) -> bool {
+    if let Some((&first, tail)) = label.split_first() {
+        if !in_inclusive_range8(first, b'0', b'9') {
+            return false;
+        }
+        for &b in tail {
+            if in_inclusive_range8(b, b'a', b'z') {
+                continue;
+            }
+            if in_inclusive_range8(b, b'0', b'9') {
+                continue;
+            }
+            if b == b'-' {
+                continue;
+            }
+            return false;
+        }
+        // A trailing hyphen stays rejected: it is both a bidi concern and a
+        // _CheckHyphens_ (V3) violation.
+        label.last() != Some(&b'-')
+    } else {
+        false
+    }
+}
+
+/// Whether a domain name may pass through labels with a leading ASCII digit,
+/// i.e. whether it cannot be a bidi domain name. A bidi domain name contains a
+/// character of Bidi property R, AL or AN, all of which are non-ASCII; an
+/// all-ASCII input reaches such a character only through an `xn--` punycode
+/// label, which always contains `--`.
+#[inline(never)]
+fn ascii_domain_permits_leading_digit_passthrough(domain_name: &[u8]) -> bool {
+    domain_name.is_ascii() && !domain_name.windows(2).any(|w| w == b"--")
+}
+
 #[inline(always)]
 fn split_ascii_fast_path_prefix(label: &[u8]) -> (&[u8], &[u8]) {
     if let Some(pos) = label.iter().position(|b| !b.is_ascii()) {
@@ -1103,6 +1143,10 @@ impl Uts46 {
         let deny_list = ascii_deny_list.bits;
         let deny_list_deny_dot = deny_list | DOT_MASK;
 
+        // Passing through a leading-digit label requires knowing the domain is
+        // not bidi; computed lazily since it is only needed for such labels.
+        let mut relax_leading_digit: Option<bool> = None;
+
         let mut had_errors = false;
 
         let mut passthrough_up_to = domain_name.len() - tail.len(); // Index into `domain_name`
@@ -1124,7 +1168,13 @@ impl Uts46 {
             // an ASCII fast path that bypasses the normalizer for ASCII
             // after a pre-existing ASCII dot (pre-existing in the sense
             // of not coming from e.g. normalizing an ideographic dot).
-            if in_prefix && is_passthrough_ascii_label(label) {
+            let can_passthrough = in_prefix
+                && (is_passthrough_ascii_label(label)
+                    || (is_leading_digit_passthrough_ascii_label(label)
+                        && *relax_leading_digit.get_or_insert_with(|| {
+                            ascii_domain_permits_leading_digit_passthrough(domain_name)
+                        })));
+            if can_passthrough {
                 if seen_label {
                     debug_assert_eq!(domain_name[passthrough_up_to], b'.');
                     passthrough_up_to += 1;

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 bencher = "0.1"
+gungraun = "0.19.4"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
@@ -51,6 +52,11 @@ harness = false
 [[bench]]
 name = "parse_url"
 path = "benches/parse_url.rs"
+harness = false
+
+[[bench]]
+name = "parse_url_gungraun"
+path = "benches/parse_url_gungraun.rs"
 harness = false
 
 [package.metadata.docs.rs]

--- a/url/benches/parse_url_gungraun.rs
+++ b/url/benches/parse_url_gungraun.rs
@@ -1,0 +1,50 @@
+//! Callgrind-based instruction-count benchmarks for URL parsing, mirroring the
+//! cases in `parse_url.rs`. Run with `cargo bench -p url --bench
+//! parse_url_gungraun` (requires Valgrind and a matching `gungraun-runner`).
+
+use std::hint::black_box;
+use std::path::PathBuf;
+
+use gungraun::{library_benchmark, library_benchmark_group, main};
+
+use url::Url;
+
+#[library_benchmark]
+#[bench::short("https://example.com/bench")]
+#[bench::long("https://example.com/parkbench?tre=es&st=uff")]
+#[bench::fragment("https://example.com/parkbench?tre=es&st=uff#fragment")]
+#[bench::plain("https://example.com/")]
+#[bench::port("https://example.com:8080")]
+#[bench::hyphen("https://hyphenated-example.com/")]
+#[bench::leading_digit("https://1test.example/")]
+#[bench::unicode_mixed("https://مثال.example/")]
+#[bench::punycode_mixed("https://xn--mgbh0fb.example/")]
+#[bench::unicode_ltr("https://නම.උදාහරණ/")]
+#[bench::punycode_ltr("https://xn--r0co.xn--ozc8dl2c3bxd/")]
+#[bench::unicode_rtl("https://الاسم.مثال/")]
+#[bench::punycode_rtl("https://xn--mgba0b1dh.xn--mgbh0fb/")]
+fn parse(url: &str) -> Url {
+    black_box(url).parse::<Url>().unwrap()
+}
+
+fn setup_file_url() -> Url {
+    let url = if cfg!(windows) {
+        "file:///C:/dir/next_dir/sub_sub_dir/testing/testing.json"
+    } else {
+        "file:///data/dir/next_dir/sub_sub_dir/testing/testing.json"
+    };
+    url.parse::<Url>().unwrap()
+}
+
+#[library_benchmark]
+#[bench::url_to_file_path(setup = setup_file_url)]
+fn url_to_file_path(url: Url) -> PathBuf {
+    black_box(url).to_file_path().unwrap()
+}
+
+library_benchmark_group!(
+    name = benches;
+    benchmarks = parse, url_to_file_path
+);
+
+main!(library_benchmark_groups = benches);

--- a/url/src/host.rs
+++ b/url/src/host.rs
@@ -96,14 +96,22 @@ impl<'a> Host<Cow<'a, str>> {
             }
             return parse_ipv6addr(&input[1..input.len() - 1]).map(Host::Ipv6);
         }
-        let domain: Cow<'_, [u8]> = percent_decode(input.as_bytes()).into();
-        let domain: Cow<'a, [u8]> = match domain {
-            Cow::Owned(v) => Cow::Owned(v),
-            // if borrowed then we can use the original cow
-            Cow::Borrowed(_) => match input {
+        // Only percent-decode when the input actually contains a `%`.
+        let domain: Cow<'a, [u8]> = if input.as_bytes().contains(&b'%') {
+            let domain: Cow<'_, [u8]> = percent_decode(input.as_bytes()).into();
+            match domain {
+                Cow::Owned(v) => Cow::Owned(v),
+                // if borrowed then we can use the original cow
+                Cow::Borrowed(_) => match input {
+                    Cow::Borrowed(input) => Cow::Borrowed(input.as_bytes()),
+                    Cow::Owned(input) => Cow::Owned(input.into_bytes()),
+                },
+            }
+        } else {
+            match input {
                 Cow::Borrowed(input) => Cow::Borrowed(input.as_bytes()),
                 Cow::Owned(input) => Cow::Owned(input.into_bytes()),
-            },
+            }
         };
 
         let domain = idna::domain_to_ascii_from_cow(domain, idna::AsciiDenyList::URL)?;
@@ -192,6 +200,19 @@ impl<S: AsRef<str>> fmt::Display for Host<S> {
                 f.write_str("[")?;
                 write_ipv6(addr, f)?;
                 f.write_str("]")
+            }
+        }
+    }
+}
+
+impl<S: AsRef<str>> Host<S> {
+    /// Appends the serialization of this host to `serialization`.
+    pub(crate) fn write_to_string(&self, serialization: &mut String) {
+        match *self {
+            Self::Domain(ref domain) => serialization.push_str(domain.as_ref()),
+            ref host => {
+                use core::fmt::Write;
+                let _ = write!(serialization, "{host}");
             }
         }
     }

--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -8,7 +8,7 @@
 
 use alloc::borrow::Cow;
 use alloc::string::String;
-use core::fmt::{self, Formatter, Write};
+use core::fmt::{self, Formatter};
 use core::str;
 
 use crate::host::{Host, HostInternal};
@@ -881,6 +881,27 @@ impl Parser<'_> {
         mut input: Input<'i>,
         scheme_type: SchemeType,
     ) -> ParseResult<(u32, Input<'i>)> {
+        // If there is no '@' before the end of the authority there is no
+        // userinfo. Tab, newline and multi-byte characters are never '@' or an
+        // authority terminator, so scanning the raw bytes reaches the same
+        // decision as the character loop below.
+        {
+            let mut has_at = false;
+            for &b in input.chars.as_str().as_bytes() {
+                match b {
+                    b'@' => {
+                        has_at = true;
+                        break;
+                    }
+                    b'/' | b'?' | b'#' => break,
+                    b'\\' if scheme_type.is_special() => break,
+                    _ => {}
+                }
+            }
+            if !has_at {
+                return Ok((to_u32(self.serialization.len())?, input));
+            }
+        }
         let mut last_at = None;
         let mut remaining = input.clone();
         let mut char_count = 0;
@@ -957,7 +978,7 @@ impl Parser<'_> {
         scheme_type: SchemeType,
     ) -> ParseResult<(u32, HostInternal, Option<u16>, Input<'i>)> {
         let (host, remaining) = Parser::parse_host(input, scheme_type)?;
-        write!(&mut self.serialization, "{host}").unwrap();
+        host.write_to_string(&mut self.serialization);
         let host_end = to_u32(self.serialization.len())?;
         if let Host::Domain(h) = &host {
             if h.is_empty() {
@@ -1023,12 +1044,12 @@ impl Parser<'_> {
         }
         let host_str;
         {
-            let host_input = input.by_ref().take(non_ignored_chars);
             if has_ignored_chars {
+                let host_input = input.by_ref().take(non_ignored_chars);
                 host_str = Cow::Owned(host_input.collect());
             } else {
-                for _ in host_input {}
                 host_str = Cow::Borrowed(&input_str[..bytes]);
+                input.chars = input_str[bytes..].chars();
             }
         }
         if scheme_type == SchemeType::SpecialNotFile && host_str.is_empty() {
@@ -1069,7 +1090,7 @@ impl Parser<'_> {
                     HostInternal::None
                 }
                 host => {
-                    write!(&mut self.serialization, "{host}").unwrap();
+                    host.write_to_string(&mut self.serialization);
                     has_host = true;
                     host.into()
                 }
@@ -1096,12 +1117,12 @@ impl Parser<'_> {
         let host_str;
         let mut remaining = input.clone();
         {
-            let host_input = remaining.by_ref().take(non_ignored_chars);
             if has_ignored_chars {
+                let host_input = remaining.by_ref().take(non_ignored_chars);
                 host_str = Cow::Owned(host_input.collect());
             } else {
-                for _ in host_input {}
                 host_str = Cow::Borrowed(&input_str[..bytes]);
+                remaining.chars = input_str[bytes..].chars();
             }
         }
         if is_windows_drive_letter(&host_str) {


### PR DESCRIPTION
Avoid redundant work on the URL parsing hot path:

- host: only percent-decode when the input contains a `%`, and append domain hosts to the serialization with `push_str` instead of `write!`.
- parser: skip the userinfo scan when the authority has no `@`, and advance the input iterator by the known byte length after scanning a host rather than re-iterating it character by character.
- idna: pass ASCII labels with a leading digit through the fast path when the domain cannot be a bidi domain name.

Add Callgrind (gungraun) instruction-count benchmarks alongside the existing wall-clock ones.

| benchmark       | instr orig | instr new |   Δ%    |  ns orig |   ns new |   ns Δ% |
|-----------------|-----------:|----------:|--------:|---------:|---------:|--------:|
| plain           |       2403 |      1823 |  -24.1% |      209 |      168 |  -19.6% |
| short           |       2653 |      2074 |  -21.8% |      243 |      186 |  -23.5% |
| long            |       3517 |      2935 |  -16.5% |      306 |      253 |  -17.3% |
| fragment        |       3887 |      3306 |  -14.9% |      344 |      285 |  -17.2% |
| port            |       2965 |      2318 |  -21.8% |      321 |      264 |  -17.8% |
| hyphen          |       3573 |      2607 |  -27.0% |      307 |      235 |  -23.5% |
| leading_digit   |       3674 |      2315 |  -37.0% |      315 |      211 |  -33.0% |
| unicode_mixed   |       6791 |      6128 |   -9.8% |      729 |      678 |   -7.0% |
| punycode_mixed  |       6105 |      5289 |  -13.4% |      607 |      498 |  -18.0% |
| unicode_ltr     |       8379 |      7609 |   -9.2% |      847 |      788 |   -7.0% |
| punycode_ltr    |       8265 |      7249 |  -12.3% |      793 |      692 |  -12.7% |
| unicode_rtl     |       8547 |      7853 |   -8.1% |      834 |      766 |   -8.2% |
| punycode_rtl    |       8336 |      7306 |  -12.4% |      780 |      660 |  -15.4% |
| url_to_file_path|       2736 |      2734 |   -0.1% |      285 |      280 |   -1.8% |