### PR TITLE
Fix panic joining a relative reference onto a file: URL with a drive-letter-shaped path segment (#1114)

### DIFF
--- a/url/src/parser.rs
+++ b/url/src/parser.rs
@@ -1414,8 +1414,12 @@ impl Parser<'_> {
             let slash_position = self.serialization[path_start..].rfind('/').unwrap();
             // + 1 since rfind returns the position before the slash.
             let segment_start = path_start + slash_position + 1;
-            // Don’t pop a Windows drive letter
+            // Don’t pop a Windows drive letter, but only when it is the sole
+            // path segment (path[0]). A drive-letter-shaped segment in a later
+            // position (e.g. "a:" in "/w:/a:") is an ordinary segment and must
+            // be popped. https://url.spec.whatwg.org/#shorten-a-urls-path
             if !(scheme_type.is_file()
+                && segment_start == path_start + 1
                 && is_normalized_windows_drive_letter(&self.serialization[segment_start..]))
             {
                 self.serialization.truncate(segment_start);

--- a/url/tests/issue_1114.rs
+++ b/url/tests/issue_1114.rs
@@ -1,0 +1,41 @@
+// Regression test for https://github.com/servo/rust-url/issues/1114
+//
+// A path segment shaped like a Windows drive letter ("a:") but NOT in drive
+// position (path[0]) is an ordinary segment and must be popped by "..".
+// Previously this panicked in debug builds (and returned the wrong path in
+// release). A genuine drive letter in drive position must still be preserved.
+
+use url::Url;
+
+#[test]
+fn issue_1114_join_pops_non_drive_position_segment() {
+    let cases = [
+        ("file:///w:/a:", "file:..", "file:///w:/"),
+        ("file:///w:/a:", "..", "file:///w:/"),
+        ("file:///C:/a:", "file:..", "file:///C:/"),
+        // a drive letter in drive position ("a:" as path[0]) is preserved
+        ("file:///a:/b", "..", "file:///a:/"),
+        ("file:///a:/b/c", "..", "file:///a:/"),
+        // a genuine sole drive letter is not over-popped
+        ("file:///w:/", "..", "file:///w:/"),
+        ("file:///w:", "..", "file:///w:/"),
+        ("file:///a:", "..", "file:///a:/"),
+    ];
+    for (base, rel, expected) in &cases {
+        let joined = Url::parse(base).unwrap().join(rel).unwrap();
+        assert_eq!(joined.as_str(), *expected, "join: {base} + {rel}");
+    }
+}
+
+#[test]
+fn issue_1114_parse_keeps_drive_letter() {
+    // ".." right after a drive letter must keep the drive letter
+    let cases = [
+        ("file:///a:/..", "file:///a:/"),
+        ("file:///c:/..", "file:///c:/"),
+        ("file:///a:/../x", "file:///a:/x"),
+    ];
+    for (input, expected) in &cases {
+        assert_eq!(Url::parse(input).unwrap().as_str(), *expected, "parse: {input}");
+    }
+}


### PR DESCRIPTION
## What

`Url::parse("file:///w:/a:").join("file:..")` (and `.join("..")`) panics on `debug_assert!(self.serialization.as_bytes()[segment_start - 1] == b'/')` in `parser.rs`, instead of resolving the path. In release builds it does not panic but returns the wrong path. Fixes #1114.

## Why

`pop_path` refuses to remove the last path segment when it is a normalized Windows drive letter. But it applied that exemption to *any* last segment shaped like a drive letter — including one that is not in drive position, e.g. the `a:` in `/w:/a:`. So during relative resolution the base's last segment is not removed, `..` is appended without a separating `/`, and the `..` branch's `debug_assert` (that `segment_start - 1` is a `/`) fires.

Per the WHATWG "shorten a URL's path" step, the drive-letter exemption applies only when the path has a single segment and `path[0]` is the drive letter:

> If url's scheme is "file", path's size is 1, and path[0] is a normalized Windows drive letter, then return.

## The fix

Restrict the `pop_path` exemption to the drive-position segment, i.e. only when `segment_start == path_start + 1`:

```rust
if !(scheme_type.is_file()
    && segment_start == path_start + 1
    && is_normalized_windows_drive_letter(&self.serialization[segment_start..]))
{
    self.serialization.truncate(segment_start);
}
```

A drive letter that really is `path[0]` (e.g. `file:///a:/..`) is still preserved.

## Verified against the spec

Affected cases checked against the WHATWG reference (`new URL(...)`):

| input | before | after / spec |
|---|---|---|
| `file:///w:/a:` + `file:..` | panic | `file:///w:/` |
| `file:///w:/a:` + `..` | panic | `file:///w:/` |
| `file:///C:/a:` + `file:..` | panic | `file:///C:/` |
| `file:///a:/..` (parse) | `file:///a:/` | `file:///a:/` (unchanged) |
| `file:///a:/b` + `..` | `file:///a:/` | `file:///a:/` (unchanged) |

The full `url_wpt` suite (urltestdata.json + setters) passes with no change to `expected_failures.txt`. A differential sweep over drive-letter inputs shows the patch alters output only on inputs that previously panicked — no previously-correct output changes.

## Tests

Adds `url/tests/issue_1114.rs`: the join cases (which panic on `main`) plus parse-time guards that a drive letter in drive position is preserved.

## Scope

Deliberately narrow: only the `pop_path` drive-position guard. It does not attempt to fix the separate, pre-existing case where multi-level paths stop popping at the first drive-letter-shaped segment (e.g. `file:///w:/a:/..`); that is left unchanged (and does not panic).

---
*Prepared with AI assistance and independently verified against the crate's full WPT suite and the WHATWG reference before submission; an earlier, broader fix was rejected during verification for regressing `file:///a:/..`, so this PR is scoped to the panic.*